### PR TITLE
chore: Update GitHub actions for the labeler and assign workflows

### DIFF
--- a/.github/workflows/auto-assign.yml
+++ b/.github/workflows/auto-assign.yml
@@ -10,7 +10,7 @@ jobs:
     if: github.event.pull_request.draft == false
     runs-on: ubuntu-latest
     steps:
-      - uses: shufo/auto-assign-reviewer-by-files@v1.1.4
+      - uses: shufo/auto-assign-reviewer-by-files@v1.1.5
         with:
           config: ".github/assign-by-files.yml"
           token: ${{ secrets.GITHUB_TOKEN }}


### PR DESCRIPTION
Update auto-assign to 1.1.5, which uses Node 16 instead of Node 12. Node 12 is deprecated on GitHub action runners.