### PR TITLE
fix(build): resolve warmerge plugin from working repo, not expired-cert archive

### DIFF
--- a/opennms-assemblies/webapp-full/pom.xml
+++ b/opennms-assemblies/webapp-full/pom.xml
@@ -207,10 +207,4 @@
       <scope>runtime</scope>
     </dependency>
   </dependencies>
-  <pluginRepositories>
-    <pluginRepository>
-      <id>opennms-repo</id>
-      <url>https://archive.opennms.com/repo-maven/maven2/</url>
-    </pluginRepository>
-  </pluginRepositories>
 </project>


### PR DESCRIPTION
## Problem

[Run #27042989385](https://github.com/Bluebird-Community/opennms/actions/runs/27042989385) failed: the **"Prepare the build for tests"** step in every `unit-tests` shard errored before any test ran, while resolving `org.opennms.maven.plugins:opennms-warmerge-plugin:0.5`:

```
Could not transfer artifact org.opennms.maven.plugins:opennms-warmerge-plugin:pom:0.5
  from/to opennms-repo (https://archive.opennms.com/repo-maven/maven2/):
  (certificate_expired) PKIX path validation failed ... validity check failed
```

`opennms-assemblies/webapp-full/pom.xml` overrode the inherited `opennms-repo` **plugin** repository to point at `https://archive.opennms.com/repo-maven/maven2/`, whose TLS certificate is expired and is rejected by the CI runner's Java truststore. (`build-with-smoke-test` passed only because it had the plugin cached; fresh unit-test shards did not.)

## Fix

Removed the module-local `<pluginRepositories>` override. The root `pom.xml` already declares `opennms-repo` → `https://maven.opennms.org/repository/everything/`, which is inherited (the `opennms-assemblies` parent adds no plugin repos) and **serves the plugin** (verified `HTTP 200`; Maven Central returns 404, so it is not published there).

## Verification

- `maven.opennms.org/.../opennms-warmerge-plugin-0.5.pom` → HTTP 200 ✅
- `webapp-full/pom.xml` validated as well-formed XML
- No remaining `pluginRepository` references `archive.opennms.com`

## Out of scope

Several `<repository>` (artifact, not plugin) declarations still reference `archive.opennms.com` (`dependencies/*`, `features/minion/*`, `core/test-api/karaf`, `core/profiler`). They did not cause this failure but carry the same expired-cert risk — a candidate follow-up sweep.

🤖 Generated with [Claude Code](https://claude.com/claude-code)