### PR TITLE
test: fix post-removal test failures

### DIFF
--- a/core/upgrade/src/main/resources/default/service-configuration-14.0.0.xml
+++ b/core/upgrade/src/main/resources/default/service-configuration-14.0.0.xml
@@ -95,6 +95,14 @@
     <invoke at="status" pass="0" method="status"/>
     <invoke at="stop" pass="0" method="stop"/>
   </service>
+  <service>
+    <name>OpenNMS:Name=Actiond</name>
+    <class-name>org.opennms.netmgt.actiond.jmx.Actiond</class-name>
+    <invoke at="start" pass="0" method="init"/>
+    <invoke at="start" pass="1" method="start"/>
+    <invoke at="status" pass="0" method="status"/>
+    <invoke at="stop" pass="0" method="stop"/>
+  </service>
   <service enabled="false">
     <name>OpenNMS:Name=Capsd</name>
     <class-name>org.opennms.netmgt.capsd.jmx.Capsd</class-name>
@@ -106,6 +114,14 @@
   <service>
     <name>OpenNMS:Name=Notifd</name>
     <class-name>org.opennms.netmgt.notifd.jmx.Notifd</class-name>
+    <invoke at="start" pass="0" method="init"/>
+    <invoke at="start" pass="1" method="start"/>
+    <invoke at="status" pass="0" method="status"/>
+    <invoke at="stop" pass="0" method="stop"/>
+  </service>
+  <service>
+    <name>OpenNMS:Name=Scriptd</name>
+    <class-name>org.opennms.netmgt.scriptd.jmx.Scriptd</class-name>
     <invoke at="start" pass="0" method="init"/>
     <invoke at="start" pass="1" method="start"/>
     <invoke at="status" pass="0" method="status"/>
@@ -142,6 +158,14 @@
      <invoke at="start" pass="1" method="start"/>
      <invoke at="status" pass="0" method="status"/>
      <invoke at="stop" pass="0" method="stop"/>
+  </service>
+  <service>
+    <name>OpenNMS:Name=EnhancedLinkd</name>
+    <class-name>org.opennms.netmgt.enlinkd.jmx.EnhancedLinkd</class-name>
+    <invoke at="start" pass="0" method="init"/>
+    <invoke at="start" pass="1" method="start"/>
+    <invoke at="status" pass="0" method="status"/>
+    <invoke at="stop" pass="0" method="stop"/>
   </service>
   <service>
     <name>OpenNMS:Name=Ticketer</name>
@@ -192,6 +216,14 @@
     <invoke at="stop" pass="0" method="stop"/>
   </service>
   <service>
+    <name>OpenNMS:Name=Statsd</name>
+    <class-name>org.opennms.netmgt.statsd.jmx.Statsd</class-name>
+    <invoke at="start" pass="0" method="init"/>
+    <invoke at="start" pass="1" method="start"/>
+    <invoke at="status" pass="0" method="status"/>
+    <invoke at="stop" pass="0" method="stop"/>
+  </service>
+  <service>
     <name>OpenNMS:Name=Provisiond</name>
     <class-name>org.opennms.netmgt.daemon.SimpleSpringContextJmxServiceDaemon</class-name>
     <attribute>
@@ -201,6 +233,22 @@
     <attribute>
       <name>SpringContext</name>
       <value type="java.lang.String">provisiondContext</value>
+    </attribute>
+    <invoke at="start" pass="0" method="init"/>
+    <invoke at="start" pass="1" method="start"/>
+    <invoke at="status" pass="0" method="status"/>
+    <invoke at="stop" pass="0" method="stop"/>
+  </service>
+  <service>
+    <name>OpenNMS:Name=Reportd</name>
+    <class-name>org.opennms.netmgt.daemon.SimpleSpringContextJmxServiceDaemon</class-name>
+    <attribute>
+      <name>LoggingPrefix</name>
+      <value type="java.lang.String">reportd</value>
+    </attribute>
+    <attribute>
+      <name>SpringContext</name>
+      <value type="java.lang.String">reportdContext</value>
     </attribute>
     <invoke at="start" pass="0" method="init"/>
     <invoke at="start" pass="1" method="start"/>
@@ -264,6 +312,14 @@
     <invoke at="stop" pass="0" method="stop"/>
   </service>
   <service enabled="false">
+    <name>OpenNMS:Name=Tl1d</name>
+    <class-name>org.opennms.netmgt.tl1d.jmx.Tl1d</class-name>
+    <invoke at="start" pass="0" method="init"/>
+    <invoke at="start" pass="1" method="start"/>
+    <invoke at="status" pass="0" method="status"/>
+    <invoke at="stop" pass="0" method="stop"/>
+  </service>
+  <service enabled="false">
     <name>OpenNMS:Name=Syslogd</name>
     <class-name>org.opennms.netmgt.syslogd.jmx.Syslogd</class-name>
     <invoke at="start" pass="0" method="init"/>
@@ -282,6 +338,14 @@
   <service enabled="false">
     <name>OpenNMS:Name=XmlrpcProvisioner</name>
     <class-name>org.opennms.netmgt.xmlrpcd.jmx.Provisioner</class-name>
+    <invoke at="start" pass="0" method="init"/>
+    <invoke at="start" pass="1" method="start"/>
+    <invoke at="status" pass="0" method="status"/>
+    <invoke at="stop" pass="0" method="stop"/>
+  </service>
+  <service enabled="false">
+    <name>OpenNMS:Name=AsteriskGateway</name>
+    <class-name>org.opennms.netmgt.asterisk.agi.jmx.AsteriskGateway</class-name>
     <invoke at="start" pass="0" method="init"/>
     <invoke at="start" pass="1" method="start"/>
     <invoke at="status" pass="0" method="status"/>

--- a/integration-tests/config/src/test/java/org/opennms/netmgt/config/WillItUnmarshalIT.java
+++ b/integration-tests/config/src/test/java/org/opennms/netmgt/config/WillItUnmarshalIT.java
@@ -249,8 +249,6 @@ public class WillItUnmarshalIT {
         addFile(Source.EXAMPLE, "destinationPaths.xml", DestinationPaths.class, false, null);
         addFile(Source.EXAMPLE, "devices/motorola_cpei_150_wimax_gateway/http-datacollection-config.xml", HttpDatacollectionConfig.class, false, null);
         addFile(Source.EXAMPLE, "discovery-configuration.xml", DiscoveryConfiguration.class, false, null);
-        addFile(Source.EXAMPLE, "event-proxy/Proxy.events.xml", Events.class, false, null);
-        addFile(Source.EXAMPLE, "event-proxy/vacuumd-configuration.xml", VacuumdConfiguration.class, false, null);
         addFile(Source.EXAMPLE, "groups.xml", Groupinfo.class, false, null);
         addFile(Source.EXAMPLE, "jvm-datacollection/collectd-configuration.xml", CollectdConfiguration.class, false, null);
         addFile(Source.EXAMPLE, "jvm-datacollection/jmx-datacollection-config.d/activemq.xml", JmxDatacollectionConfig.class, false, null);


### PR DESCRIPTION
Follow-up to the deprecated-code removal (PRs #131–#138): fixes the test failures the removals caused. Found by running the unit-test suite across all touched modules + the config integration test.

## Fixes
1. **Restore the frozen 14.0.0 service-configuration baseline** — `core/upgrade/src/main/resources/default/service-configuration-14.0.0.xml` is a frozen historical snapshot of the OpenNMS 14.0.0 service set (used by `ServiceConfigMigratorOffline` as its migration baseline; `ServiceConfigMigratorOfflineTest` explicitly says "do not change this value … regardless of whether services are removed in the latest version"). The daemon-removal phases incorrectly trimmed it (it sits under `src/main/resources`, outside the "frozen *test* fixture" carve-out). Restored to the original 38-service content → `ServiceConfigMigratorOfflineTest` green (38/27). Removed daemons are handled at the active shipped config + EOL-migrator layer, not by rewriting the historical baseline.
2. **Drop deleted `event-proxy` example entries from `WillItUnmarshalIT`** — phase 6a deleted the scriptd `examples/event-proxy/` dir but left two `addFile` entries (`Proxy.events.xml`, `vacuumd-configuration.xml`); removed them → `WillItUnmarshalIT` green (834 tests).

## Test status
- **Unit tests** across all touched modules (`core/upgrade`, `config-tester`, `web-api`, `config-model`, `webapp-rest`, `status/*`, `datachoices`, `api-layer`, `measurements/impl`, `distributed/dao`, `events/traps`, `opennms-dao`, `opennms-webapp`, `opennms-model`, …) → **all pass** (these 2 were the only failures).
- **`WillItUnmarshalIT`** (834 config-unmarshal cases) → **pass**.

🤖 Generated with [Claude Code](https://claude.com/claude-code)