### PR TITLE
fix: remove dangling opennms-integration-rt dependency refs

### DIFF
--- a/opennms-base-assembly/pom.xml
+++ b/opennms-base-assembly/pom.xml
@@ -367,10 +367,6 @@
       <type>pom</type>
     </dependency>
     <dependency>
-      <groupId>org.opennms.features</groupId>
-      <artifactId>opennms-integration-rt</artifactId>
-    </dependency>
-    <dependency>
       <groupId>org.opennms</groupId>
       <artifactId>opennms-rrd-model</artifactId>
       <scope>compile</scope>

--- a/opennms-config-tester/pom.xml
+++ b/opennms-config-tester/pom.xml
@@ -64,10 +64,6 @@
       <artifactId>org.opennms.features.springframework-security</artifactId>
     </dependency>
     <dependency>
-      <groupId>org.opennms.features</groupId>
-      <artifactId>opennms-integration-rt</artifactId>
-    </dependency>
-    <dependency>
       <groupId>org.opennms</groupId>
       <artifactId>opennms-snmp-asset-provisioning-adapter</artifactId>
     </dependency>

--- a/pom.xml
+++ b/pom.xml
@@ -3386,11 +3386,6 @@
         <version>${project.version}</version>
       </dependency>
       <dependency>
-        <groupId>org.opennms.features</groupId>
-        <artifactId>opennms-integration-rt</artifactId>
-        <version>${project.version}</version>
-      </dependency>
-      <dependency>
         <groupId>org.opennms</groupId>
         <artifactId>opennms-install</artifactId>
         <version>${project.version}</version>


### PR DESCRIPTION
## Problem

The `main` branch build (`Build tarballs, oci and packages with test suites`) is failing at `make quick-compile`:

```
Failed to execute goal on project opennms-config-tester: Could not resolve dependencies
  dependency: org.opennms.features:opennms-integration-rt:jar:37.0.1-SNAPSHOT (compile)
    Could not find artifact org.opennms.features:opennms-integration-rt:jar:37.0.1-SNAPSHOT
```

## Root cause

Phase 3a of the deprecated-code removal initiative (`8348d1a31a2 chore: remove deprecated modules + their consumers (phase 3a)`) deleted the RT ticketer module `features/ticketing/rt-integration` (artifactId `opennms-integration-rt`, providing `RtTicketerPlugin`) but left three dangling references:

- root `pom.xml` — `dependencyManagement` entry
- `opennms-base-assembly/pom.xml` — compile dependency
- `opennms-config-tester/pom.xml` — compile dependency

## Fix

Remove all three references. No remaining Java source or runtime config references `RtTicketerPlugin` / `org.opennms.netmgt.ticketer.rt`, so the dependencies are safe to drop.

## Verification

`./compile.pl -DskipTests=true --projects :opennms-config-tester install` → **BUILD SUCCESS** (previously failed at dependency resolution).

🤖 Generated with [Claude Code](https://claude.com/claude-code)