### PR TITLE
fix: drop unmatched slf4j-jdk14 exclude from daemon assembly

### DIFF
--- a/opennms-base-assembly/src/assembly/daemon.xml
+++ b/opennms-base-assembly/src/assembly/daemon.xml
@@ -90,7 +90,6 @@
         <exclude>org.opennms:opennms-install</exclude>
         <exclude>org.opennms.core:org.opennms.core.password</exclude>
         <exclude>org.opennms.features:org.opennms.features.system-report</exclude>
-        <exclude>org.slf4j:slf4j-jdk14</exclude>
         <exclude>io.pyroscope:agent</exclude>
         <exclude>org.jacoco:org.jacoco.agent:jar:runtime</exclude>
         <!-- Exclude the dependency POMs -->


### PR DESCRIPTION
## Problem

After PR #140 fixed `quick-compile`, the main build advanced to `quick-assemble` and failed:

```
Failed to execute goal maven-assembly-plugin:3.7.1:single (default) on project opennms-base-assembly:
  Assembly is incorrectly configured: daemon:
  Assembly: daemon is not configured correctly: One or more filters had unmatched criteria.
```

## Root cause

`daemon.xml` has a `useStrictFiltering=true` dependencySet that excludes `org.slf4j:slf4j-jdk14`. Phase 1 (`b94b4368900`) removed `integrations/opennms-jasperstudio-extension`, the **only** module that declared `slf4j-jdk14`. It now appears in zero poms, so it can never be in `opennms-base-assembly`'s dependency tree — making the exclude an unmatched criterion, which strict filtering treats as a fatal error.

Masked until now because `quick-assemble` only runs after `quick-compile`, which had been failing on the dangling `opennms-integration-rt` dep (fixed in #140).

## Fix

Remove the dead `<exclude>org.slf4j:slf4j-jdk14</exclude>`. All other strict include/exclude criteria in `daemon.xml` still reference artifacts present as direct base-assembly dependencies (verified).

## Verification

Static: `slf4j-jdk14` appears in no `pom.xml` (`grep -rl slf4j-jdk14 --include=pom.xml` → empty). The root `pom.xml` trip-wire path triggers a full CI build that exercises `quick-assemble`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)