### PR TITLE
fix: ship hibernate-validator in core lib for Hibernate validation

### DIFF
--- a/opennms-base-assembly/pom.xml
+++ b/opennms-base-assembly/pom.xml
@@ -371,6 +371,14 @@
       <artifactId>opennms-rrd-model</artifactId>
       <scope>compile</scope>
     </dependency>
+    <!-- Bean Validation provider required at runtime by the Hibernate
+         sessionFactory (applicationContext-shared.xml). Previously pulled
+         transitively via the bsm/enlinkd modules removed in phase 6b. -->
+    <dependency>
+      <groupId>org.hibernate</groupId>
+      <artifactId>hibernate-validator</artifactId>
+      <scope>runtime</scope>
+    </dependency>
     <dependency>
       <groupId>org.opennms</groupId>
       <artifactId>opennms-rrd-util</artifactId>


### PR DESCRIPTION
## Problem

After #140 and #141 unblocked compile + assemble, the main build advanced to the smoke test, where the core container fails to start:

```
org.hibernate.HibernateException: Unable to get the default Bean Validation factory
  at sessionFactory (META-INF/opennms/applicationContext-shared.xml, opennms-dao)
...
ContainerLaunchException: Container startup failed for image local/core:latest
```

## Root cause

The Hibernate `sessionFactory` needs a Bean Validation (JSR-303) **provider** on the runtime classpath. The `validation-api` (the API) is present, but the provider (`hibernate-validator`) was only reaching `/opt/opennms/lib` transitively via the bsm/enlinkd modules removed in phase 6b (`c1c2870c368`). Unit/integration tests still pass because the provider is on their test classpath — only the assembled runtime lost it. "API present, provider absent" is exactly what this Hibernate error reports.

## Fix

Add `hibernate-validator` (managed version, `runtime` scope) as a dependency of `opennms-base-assembly` so it — and its transitive provider deps — are packaged into the core distribution `lib/` again. Placed at the distribution boundary because the gap is in the assembled runtime, not in any module's compile/test classpath.

## Verification

The `build-with-smoke-test` job runs `make smoke` on every commit, which builds the core OCI and starts the container — directly exercising the failing `sessionFactory` init.

🤖 Generated with [Claude Code](https://claude.com/claude-code)