### PR TITLE
fix: provision geolocation feature bundles into core system repo

### DIFF
--- a/opennms-full-assembly/pom.xml
+++ b/opennms-full-assembly/pom.xml
@@ -437,6 +437,11 @@
                 <feature>jira-troubleticketer</feature>
                 <feature>tsrm-troubleticketer</feature>
                 <feature>datachoices</feature>
+                <!-- Boot feature (org.apache.karaf.features.cfg); its geocoder/geolocation
+                     bundles were previously pulled into system/ transitively via the
+                     opennms-topology-runtime-base feature removed in phase 4. List it
+                     explicitly so the bundles are provisioned into the repo. -->
+                <feature>geolocation</feature>
                 <feature>eif-adapter</feature>
                 <feature>opennms-telemetry-collection</feature>
                 <feature>opennms-telemetry-bmp</feature>


### PR DESCRIPTION
## Problem

After #142 cleared the Hibernate error, the core container boots further and now Karaf fails to resolve the `geolocation` boot feature's bundles:

```
Error resolving artifact org.opennms.features.geocoder:org.opennms.features.geocoder.api:jar:...
  (+ geocoder.rest/service/google/mapquest/nominatim, geolocation.api/services)
Karaf: Could not find artifact ... -> Container exited with code 1 -> ContainerLaunchException
```

## Root cause

`geolocation` is a boot feature (`org.apache.karaf.features.cfg`), so its bundles must be in the baked Karaf `system/` repo (`opennms-full-assembly/target/opennms-repo`, built by `karaf-maven-plugin:features-add-to-repository`). They were only ever pulled in **transitively**, via the `opennms-topology-runtime-base` feature (which declared `<feature>geolocation</feature>`) removed in phase 4 (`26204be291b`, Vaadin/topology-map removal). With that gone, nothing lists `geolocation` in the repo feature set, so its bundles are absent from `system/` and Karaf can't resolve them at boot.

The container's `featuresBoot` also still lists other removed features (dashlet/vaadin/topology-runtime/dhcpd/reporting/etc.), but those are merely **missing definitions**, which Karaf tolerates with a warning — only `geolocation` (definition kept, bundles missing) is fatal. The boot log confirms `geolocation`/geocoder is the sole hard failure. Cleaning the stale `featuresBoot` entries is hygiene for a follow-up; not required for green.

## Fix

Add `<feature>geolocation</feature>` to the `features-add-to-repository` list in `opennms-full-assembly/pom.xml`, restoring its bundles to `system/`.

## Verification

`build-with-smoke-test` runs `make smoke` (builds the core OCI, boots Karaf) on every commit — directly exercising the failing feature resolution.

🤖 Generated with [Claude Code](https://claude.com/claude-code)