### PR TITLE
fix: ship freemarker in core lib for legacy webapp NavBarController

### DIFF
--- a/opennms-base-assembly/pom.xml
+++ b/opennms-base-assembly/pom.xml
@@ -379,6 +379,15 @@
       <artifactId>hibernate-validator</artifactId>
       <scope>runtime</scope>
     </dependency>
+    <!-- FreeMarker is referenced by the legacy webapp (NavBarController) with
+         onmsLibScope=provided, i.e. expected in the shared lib/. Previously
+         pulled into lib/ transitively via a module removed in phase 3a. -->
+    <dependency>
+      <groupId>org.freemarker</groupId>
+      <artifactId>freemarker</artifactId>
+      <version>${freemarkerVersion}</version>
+      <scope>runtime</scope>
+    </dependency>
     <dependency>
       <groupId>org.opennms</groupId>
       <artifactId>opennms-rrd-util</artifactId>


### PR DESCRIPTION
## Problem

After #143 cleared the Karaf geolocation failure, the core container boots further and the legacy webapp Spring context now fails:

```
Failed to introspect bean class [org.opennms.web.controller.NavBarController] ...
  NoClassDefFoundError: freemarker/template/Configuration
  ClassNotFoundException: freemarker.template.Configuration
```

## Root cause

`NavBarController` renders the nav bar via FreeMarker. `opennms-webapp` declares `freemarker` with `onmsLibScope=provided` — i.e. it expects the jar in the shared `/opt/opennms/lib`, not bundled in `WEB-INF/lib`. That jar reached `lib/` only transitively, via a module removed in phase 3a (`8348d1a31a2`). It's now absent, so the webapp classloader (a child of the shared-lib classloader) can't find it.

## Fix

Add `freemarker` as a `runtime` dependency of `opennms-base-assembly` so it ships in the core distribution `lib/` again — the same remediation used for `hibernate-validator` in #142.

## Verification

`build-with-smoke-test` runs `make smoke` (builds the core OCI, boots the webapp Spring context) on every commit — directly exercising NavBarController init.

🤖 Generated with [Claude Code](https://claude.com/claude-code)