### PR TITLE
fix(ci): make test-list output deterministic so integration-test shards don't duplicate tests

### DIFF
--- a/.cicd-assets/find-tests/find-tests.py
+++ b/.cicd-assets/find-tests/find-tests.py
@@ -96,6 +96,8 @@ def generate_test_lists(maven_project_root, changes_only=True, unit_test_output=
         itest_file = open(integration_test_output, 'w')
 
     print("Modules with tests:")
+    unit_classnames = []
+    itest_classnames = []
     for m in modules_to_consider:
         if m.has_tests():
             print(m)
@@ -103,11 +105,22 @@ def generate_test_lists(maven_project_root, changes_only=True, unit_test_output=
                 print("\t%s - %s (%s)" % (test.file, test.classname, "Failsafe" if test.is_integration_test else "Surefire"))
 
                 if not test.is_integration_test:
-                    if unit_file:
-                        unit_file.write("%s\n" % test.classname)
+                    unit_classnames.append(test.classname)
                 else:
-                    if itest_file:
-                        itest_file.write("%s\n" % test.classname)
+                    itest_classnames.append(test.classname)
+
+    # CI shards these lists by line number (awk "NR%shards==idx"), which only
+    # partitions tests correctly when every shard job sees an identical ordering.
+    # modules_to_consider may be a set (scoped builds) whose iteration order is
+    # non-deterministic across processes, so sort + de-duplicate before writing
+    # to guarantee a stable, shard-safe ordering (otherwise shards both duplicate
+    # and skip tests).
+    if unit_file:
+        for classname in sorted(set(unit_classnames)):
+            unit_file.write("%s\n" % classname)
+    if itest_file:
+        for classname in sorted(set(itest_classnames)):
+            itest_file.write("%s\n" % classname)
 
 
 def generate_test_modules(maven_project_root, test_class_names, output_file):


### PR DESCRIPTION
## Problem

The 8 integration-test shard jobs run **the same tests** instead of distributing them (also affects unit-test and e2e shards).

## Root cause

All shard jobs split tests by line number:

```
awk "NR%MAVEN_SHARDS==MAVEN_SHARD_IDX"   # over *_tests_classnames
```

Each shard job regenerates `integration_tests_classnames` independently via `find-tests.py` (the `test-lists` Make prerequisite). Line-number partitioning is only correct if **every job sees an identical ordering**.

In scoped builds (`full_build=false`), `modules_to_consider` is a Python `set` (`find-tests.py:80`), and the classnames were written in set-iteration order. Set iteration over module objects is **non-deterministic across processes**, so each shard job got a different ordering → the same `NR%8==idx` slice selected overlapping tests (duplicates) and missed others.

## Fix

Collect the classnames and write them **sorted + de-duplicated**, so the output is stable and identical across all shard jobs.

## Verification

`generate-test-lists` (scoped path) now produces byte-identical integration lists across `PYTHONHASHSEED=1` and `=2` (62 tests, all unique) — previously the ordering varied with the hash seed. Full-path output is likewise identical run-to-run.

`.cicd-assets/**` is a trip-wire path, so this PR triggers a full CI build that exercises all 8 shards.

🤖 Generated with [Claude Code](https://claude.com/claude-code)