### PR TITLE
fix(test): give the dao-mock Hibernate harness a Bean Validation provider

### DIFF
--- a/opennms-dao-mock/pom.xml
+++ b/opennms-dao-mock/pom.xml
@@ -33,6 +33,16 @@
       <artifactId>opennms-dao</artifactId>
       <scope>runtime</scope>
     </dependency>
+    <!-- Bean Validation provider required at runtime by the Hibernate
+         sessionFactory in opennms-dao's applicationContext-shared.xml. It used
+         to reach dao-mock consumers' test classpaths transitively; the
+         deprecated-module removals pruned that path, so declare it here so every
+         Hibernate-backed test using this harness can initialise the context. -->
+    <dependency>
+      <groupId>org.hibernate</groupId>
+      <artifactId>hibernate-validator</artifactId>
+      <scope>runtime</scope>
+    </dependency>
     <dependency>
       <groupId>org.opennms.features.config.service</groupId>
       <artifactId>org.opennms.features.config.service.api</artifactId>


### PR DESCRIPTION
## Problem

With the smoke test now green, the full build's unit tests fail in modules that use the `opennms-dao-mock` test harness, e.g. shard 0:

```
OpenConfigLocationPublisherTest » IllegalState Failed to load ApplicationContext
  bean 'sessionFactory' (META-INF/opennms/applicationContext-shared.xml)
  org.hibernate.HibernateException: Unable to get the default Bean Validation factory
```

## Root cause

`opennms-dao-mock` depends on `opennms-dao` (runtime) to spin up the Hibernate `sessionFactory` for tests. That context needs a Bean Validation (JSR-303) **provider**. `validation-api` is present, but the provider (`hibernate-validator`) only reached these test classpaths **transitively** — and the deprecated-module removals pruned that path. Same root cause as the assembled-core runtime fix (#142, via base-assembly); here it's the shared test harness used by **~97 modules**.

## Fix

Declare `hibernate-validator` (runtime scope) in `opennms-dao-mock`. Because consumers depend on dao-mock at `test` scope, the provider lands on their **test** classpath only — no production/OSGi impact — and systemically fixes every Hibernate-backed test using the harness, rather than patching modules one at a time.

## Verification

Local: rebuilt the `openconfig.itests` closure with the fix and ran `OpenConfigLocationPublisherTest` (was failing to load the context). CI runs the affected unit-test shards.

🤖 Generated with [Claude Code](https://claude.com/claude-code)