### PR TITLE
fix(test): restore events.daemon on the config IT classpath (Eventd ClassNotFound)

### DIFF
--- a/integration-tests/config/pom.xml
+++ b/integration-tests/config/pom.xml
@@ -91,6 +91,15 @@
       <artifactId>org.opennms.features.events.traps</artifactId>
       <scope>test</scope>
     </dependency>
+    <!-- Provides org.opennms.netmgt.eventd.jmx.Eventd, referenced by the default
+         service-configuration.xml that ServiceConfigurationPublicConstructorIT
+         loads. It used to be pulled in transitively via enlinkd.daemon, removed
+         in phase 6b. -->
+    <dependency>
+      <groupId>org.opennms.features.events</groupId>
+      <artifactId>org.opennms.features.events.daemon</artifactId>
+      <scope>test</scope>
+    </dependency>
     <dependency>
       <groupId>org.opennms.features</groupId>
       <artifactId>org.opennms.features.discovery</artifactId>


### PR DESCRIPTION
## Problem

`ServiceConfigurationPublicConstructorIT.testPublicConstructors` fails:

```
java.lang.ClassNotFoundException: org.opennms.netmgt.eventd.jmx.Eventd
  at ServiceConfigurationPublicConstructorIT.getClasses(...:54)
```

The test reads the default `service-configuration.xml` and calls `Class.forName` on every daemon service class.

## Root cause

`Eventd` is a kept core daemon, but its class now lives **only** in `org.opennms.features.events.daemon` (upstream moved Eventd into its own JAR). The `integration-tests/config` module received that module **transitively via `org.opennms.features.enlinkd.daemon`**, which **phase 6b (`c1c2870c368`) removed** from this pom — dropping `Eventd` off the test classpath. Same "removal pruned a needed transitive dependency" pattern as the earlier fixes.

## Fix

Add `org.opennms.features.events.daemon` (test scope) directly to `integration-tests/config/pom.xml`.

## Verification

- Confirmed `org.opennms.netmgt.eventd.jmx.Eventd` exists in `features/events/daemon` and resolves once the module is on the classpath.
- Statically verified **every** `<class-name>` in the default `service-configuration.xml` still exists in source — no other missing classes lurking after Eventd.

(Local full-IT execution was blocked by an unrelated Karaf feature-verification step pulled into the `-am` closure; CI runs the IT on a clean runner.)

🤖 Generated with [Claude Code](https://claude.com/claude-code)