### PR TITLE
test(e2e): drop businessEdgeCount assertion from UsageStatisticsIT [full-ci]

### DIFF
--- a/e2e-tests/src/test/java/org/opennms/smoketest/UsageStatisticsIT.java
+++ b/e2e-tests/src/test/java/org/opennms/smoketest/UsageStatisticsIT.java
@@ -123,7 +123,6 @@ public class UsageStatisticsIT {
         assertThat((String) usageReport.get("installedOIAPlugins"), not(emptyString()));
         assertThat((long) usageReport.get("onCallRoleCount"), is(0L));
         assertThat((long) usageReport.get("requisitionCount"), is(0L));
-        assertThat((long) usageReport.get("businessEdgeCount"), is(0L));
         assertThat((String) usageReport.get("sinkStrategy"), is("camel"));
         assertThat((String) usageReport.get("rpcStrategy"), is("jms"));
         assertThat((String) usageReport.get("tssStrategies"), is("rrd"));


### PR DESCRIPTION
## Summary

Follow-up to #151. The full e2e build (run 27995023658) showed `UsageStatisticsIT` still failing — this time with an NPE, not the services-count mismatch #151 fixed:

```
java.lang.NullPointerException: Cannot invoke "java.lang.Long.longValue()"
because the return value of "java.util.Map.get(Object)" is null
  at org.opennms.smoketest.UsageStatisticsIT.testUsageStatistics(UsageStatisticsIT.java:126)
```

Line 126 was `assertThat((long) usageReport.get("businessEdgeCount"), is(0L))`. **BSM was removed**, so `UsageStatisticsReportDTO` no longer has a `businessEdgeCount` getter and the report JSON omits the key → `get()` returns null → NPE on unboxing. This was masked until #151 fixed the earlier `services.size()` assertion; with that unblocked, the test reached line 126.

## Verification

Compared every `usageReport.get("…")` key the test reads (49 keys) against the DTO's getters — **`businessEdgeCount` is the only key with no corresponding getter**, so removing this one assertion fully resolves the test. `[full-ci]` requested to validate on the full e2e suite.

🤖 Generated with [Claude Code](https://claude.com/claude-code)