### PR TITLE
ci(e2e): upload container logs (karaf.log etc.) from e2e jobs

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -673,6 +673,8 @@ jobs:
             target/artifacts/failsafe-reports
             target/artifacts/recordings
             target/artifacts/smoke-test-*.tar.gz
+            target/artifacts/logs.tar.gz
+            target/artifacts/e2e-tests-logs.tar.gz
 
   e2e-tests-minion:
     if: "needs.decide-scope.outputs.full_build == 'true' && !contains(github.event.commits[0].message, '[skip e2e-tests-minion]')"
@@ -729,6 +731,8 @@ jobs:
             target/artifacts/failsafe-reports
             target/artifacts/recordings
             target/artifacts/smoke-test-*.tar.gz
+            target/artifacts/logs.tar.gz
+            target/artifacts/e2e-tests-logs.tar.gz
 
   e2e-tests-sentinel:
     if: "needs.decide-scope.outputs.full_build == 'true' && !contains(github.event.commits[0].message, '[skip e2e-tests-sentinel]')"
@@ -785,6 +789,8 @@ jobs:
             target/artifacts/failsafe-reports
             target/artifacts/recordings
             target/artifacts/smoke-test-*.tar.gz
+            target/artifacts/logs.tar.gz
+            target/artifacts/e2e-tests-logs.tar.gz
 
   publish-packages:
     needs:


### PR DESCRIPTION
## Summary

Server-side e2e failures (notably the minion `JtiTelemetryIT` / `NxosTelemetryIT` / `IntegrationAPIIT` timeouts) can't be diagnosed from CI because the **OpenNMS/Minion `karaf.log` never reaches the artifact bundle** — only surefire/failsafe reports and maven logs do.

The plumbing already exists:
- `OpenNMSContainer.afterTest` → `retainLogsfNeeded` → `DevDebugUtils.copyLogs(...)` writes `karaf.log`, `telemetryd.log`, `manager.log`, etc. into `e2e-tests/target/logs/<test>/<alias>`.
- `make collect-testresults` (run with `if: always()`) tars `e2e-tests/target/logs` into `target/artifacts/e2e-tests-logs.tar.gz`.

The **only** gap: the `upload-artifact` `path:` lists for the core/minion/sentinel e2e jobs didn't include those tarballs. This adds `logs.tar.gz` and `e2e-tests-logs.tar.gz` to all three.

## Effect

Next full e2e run, the `e2e-tests-*-artifacts-*` bundles will contain the container logs, making telemetry-persistence and OSGi failures diagnosable.

This touches `.github/workflows/**` (a CI trip-wire path), so this PR runs a full build automatically and will exercise the new capture.

🤖 Generated with [Claude Code](https://claude.com/claude-code)