### PR TITLE
fix(features): give scripted telemetry adapters the Groovy engine [full-ci]

### DIFF
--- a/container/features/src/main/resources/features.xml
+++ b/container/features/src/main/resources/features.xml
@@ -951,6 +951,11 @@
         <feature>opennms-collection-api</feature>
         <feature>opennms-thresholding-api</feature>
         <feature>opennms-osgi-jsr223</feature>
+        <!-- Scripted telemetry adapters (JTI, NX-OS, sFlow, NetFlow, Graphite) compile their
+             etc/telemetryd-adapters/*.groovy scripts via JSR-223, so the Groovy engine must be
+             present. Previously it was only pulled in transitively by opennms-newts, which left
+             RRD-based setups without an engine ("No engine found for extension: groovy"). -->
+        <feature>groovy</feature>
         <bundle dependency="true">wrap:mvn:com.google.protobuf/protobuf-java/${protobufVersion}</bundle>
         <bundle>mvn:com.google.code.gson/gson/${gsonVersion}</bundle>
         <bundle>wrap:mvn:io.pkts/pkts-core/${pktsVersion}</bundle>


### PR DESCRIPTION
## Problem

`JtiTelemetryIT`, `NxosTelemetryIT`, and `IntegrationAPIIT` (all on `OpenNMSStack.MINION`) have been failing — telemetry packets are sent but never persist an RRD, so the tests time out. With `karaf.log` now captured in e2e artifacts (#153), the OpenNMS-side root cause is visible:

```
ERROR | JmsConsumer[OpenNMS.Sink.Telemetry-JTI] | AbstractAdapter |
  Failed to create builder for script 'etc/telemetryd-adapters/junos-telemetry-interface.groovy'.
java.lang.IllegalStateException: No engine found for extension: groovy
```

## Root cause

Scripted telemetry adapters (JTI, NX-OS, sFlow, NetFlow, Graphite) compile their `etc/telemetryd-adapters/*.groovy` scripts through JSR-223. The Groovy `ScriptEngineFactory` ships in the **`groovy`** feature (the `groovy-jsr223` bundle), but `opennms-telemetry-collection` declared only **`opennms-osgi-jsr223`** — the JSR-223 *discovery* framework — not the engine itself.

The `groovy` feature was being pulled in only **transitively via `opennms-newts`**. On RRD-based stacks (like the minion e2e stack, `tssStrategies=rrd`) Newts isn't installed, so no Groovy engine is present and every scripted adapter fails.

## Fix

Declare `<feature>groovy</feature>` directly on `opennms-telemetry-collection` (the shared feature that contains the scripted-adapter bundle and is depended on by JTI/NX-OS/BMP/etc.), so scripted adapters always have their engine regardless of the time-series strategy.

## Validation

Touches `container/features/**` (a trip-wire path) → this PR runs the full e2e suite; the minion telemetry ITs should now pass. Not locally verifiable (requires the containerised stack).

🤖 Generated with [Claude Code](https://claude.com/claude-code)