### PR TITLE
build(packaging): migrate deb/rpm packaging from fpm to nfpm [full-ci]

### DIFF
--- a/.github/actions/setup-nfpm/action.yml
+++ b/.github/actions/setup-nfpm/action.yml
@@ -1,0 +1,32 @@
+name: Setup nfpm
+description: Install a pinned, checksum-verified nfpm binary onto PATH for package builds.
+
+inputs:
+  version:
+    description: nfpm version to install (without the leading v).
+    required: false
+    # renovate: datasource=github-releases depName=goreleaser/nfpm
+    default: "2.47.0"
+  sha256:
+    description: SHA-256 of nfpm_<version>_Linux_x86_64.tar.gz.
+    required: false
+    default: "0660ca602b2d2d2ae4781a06c692b3eeb9d437ffea05b831d76e41f4a3188783"
+
+runs:
+  using: composite
+  steps:
+    - name: Download and verify nfpm
+      shell: bash
+      run: |
+        set -euo pipefail
+        version="${{ inputs.version }}"
+        sha256="${{ inputs.sha256 }}"
+        tarball="nfpm_${version}_Linux_x86_64.tar.gz"
+        url="https://github.com/goreleaser/nfpm/releases/download/v${version}/${tarball}"
+        tmp="$(mktemp -d)"
+        curl -fsSL -o "${tmp}/${tarball}" "${url}"
+        echo "${sha256}  ${tmp}/${tarball}" | sha256sum -c -
+        tar -xzf "${tmp}/${tarball}" -C "${tmp}" nfpm
+        install -m 0755 "${tmp}/nfpm" /usr/local/bin/nfpm
+        rm -rf "${tmp}"
+        nfpm --version

--- a/.github/renovate.json
+++ b/.github/renovate.json
@@ -1,6 +1,17 @@
 {
   "$schema": "https://docs.renovatebot.com/renovate-schema.json",
   "extends": ["config:base"],
+  "customManagers": [
+    {
+      "customType": "regex",
+      "description": "Track the pinned nfpm version in the setup-nfpm composite action. NOTE: Renovate bumps the version only; the sha256 default must be refreshed by hand from the release checksums.txt when the bump PR lands.",
+      "fileMatch": ["^\\.github/actions/setup-nfpm/action\\.yml$"],
+      "matchStrings": [
+        "# renovate: datasource=(?<datasource>\\S+) depName=(?<depName>\\S+)\\s+default:\\s+\"(?<currentValue>[^\"]+)\""
+      ],
+      "extractVersionTemplate": "^v?(?<version>.+)$"
+    }
+  ],
   "packageRules": [
     {
       "managers": ["npm"],

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -246,6 +246,8 @@ jobs:
         with:
           name: tarball-core
           path: opennms-full-assembly/target
+      - name: Install nfpm
+        uses: ./.github/actions/setup-nfpm
       - name: Build Core Debian packages
         run: make core-pkg-deb PKG_RELEASE=${{ github.run_number }}
       - name: Build Core RPM packages
@@ -273,6 +275,8 @@ jobs:
         with:
           name: tarball-minion
           path: opennms-assemblies/minion/target
+      - name: Install nfpm
+        uses: ./.github/actions/setup-nfpm
       - name: Build Minion Debian packages
         run: make minion-pkg-deb PKG_RELEASE=${{ github.run_number }}
       - name: Build Minion RPM packages
@@ -300,6 +304,8 @@ jobs:
         with:
           name: tarball-sentinel
           path: opennms-assemblies/sentinel/target
+      - name: Install nfpm
+        uses: ./.github/actions/setup-nfpm
       - name: Build Sentinel Debian packages
         run: make sentinel-pkg-deb PKG_RELEASE=${{ github.run_number }}
       - name: Build Sentinel RPM packages

--- a/Makefile
+++ b/Makefile
@@ -57,6 +57,7 @@ PKG_SENTINEL_DEPLOY   := /var/lib/sentinel/deploy
 BUILD_ROOT            := $(ARTIFACTS_DIR)/buildroot
 PKG_RELEASE           := $(RELEASE_BUILD_NUM)
 MAINTAINER_EMAIL      ?= maintainer@bluebirdops.org
+ARCH                  ?= amd64
 
 INSTALL_VERSION       := ${OPENNMS_VERSION}-${RELEASE_COMMIT}
 DEPLOY_BASE_IMAGE     := quay.io/bluebird/deploy-base:5.0.0.b46
@@ -211,8 +212,13 @@ deps-build:
 .PHONY: deps-packages
 deps-packages:
 	@echo "Check dependencies to build packages"
-	command -v fpm
-	command -v rpmbuild
+	@command -v nfpm >/dev/null 2>&1 || { \
+		echo "nfpm not found. Install it to build packages:"; \
+		echo "  brew install nfpm"; \
+		echo "  go install github.com/goreleaser/nfpm/v2/cmd/nfpm@latest"; \
+		echo "  (CI installs a pinned binary via .github/actions/setup-nfpm)"; \
+		exit 1; \
+	}
 
 .PHONY: deps-docs
 deps-docs:
@@ -531,25 +537,8 @@ core-pkg-deb: deps-packages core-pkg-buildroot
 	@echo "Version:     " $(OPENNMS_VERSION)
 	@echo "Release:     " $(PKG_RELEASE)
 	@echo
-	fpm -s dir -t deb -p $(ARTIFACTS_DIR)/packages/core/NAME_VERSION_ARCH_$(PKG_RELEASE).deb \
-		-n "bbo-core" \
-		-v "$(OPENNMS_VERSION)-$(PKG_RELEASE)" \
-		--config-files /opt/opennms/etc \
-		--description "BluebirdOps Core services" \
-		--url "https://github.com/bluebird-community/opennms" \
-		--maintainer "Maintainer <$(MAINTAINER_EMAIL)>" \
-		--depends jicmp \
-		--depends jicmp6 \
-		--depends jrrd2 \
-		--deb-recommends openjdk-17-jdk-headless \
-		--deb-suggests "postgresql (>= 14.0)" \
-		--deb-suggests iplike-pgsql14 \
-		--deb-suggests iplike-pgsql15 \
-		--deb-suggests iplike-pgsql16 \
-		--deb-suggests iplike-pgsql17 \
-		--deb-suggests iplike-pgsql18 \
-		--after-install packages/pkg-postinst-core.sh \
-		-C "$(BUILD_ROOT)/core"
+	ARCH="$(ARCH)" OPENNMS_VERSION="$(OPENNMS_VERSION)" PKG_RELEASE="$(PKG_RELEASE)" MAINTAINER_EMAIL="$(MAINTAINER_EMAIL)" \
+		nfpm package --packager deb --config nfpm/nfpm-core.yaml --target "$(ARTIFACTS_DIR)/packages/core/"
 
 .PHONY: core-pkg-rpm
 core-pkg-rpm: deps-packages core-pkg-buildroot
@@ -558,25 +547,8 @@ core-pkg-rpm: deps-packages core-pkg-buildroot
 	@echo "Version:     " $(OPENNMS_VERSION)
 	@echo "Release:     " $(PKG_RELEASE)
 	@echo
-	fpm -s dir -t rpm -p $(ARTIFACTS_DIR)/packages/core/NAME_VERSION_ARCH_$(PKG_RELEASE).rpm \
-	    -n "bbo-core" \
-		-v "$(OPENNMS_VERSION)_$(PKG_RELEASE)" \
-		--config-files /opt/opennms/etc \
-		--description "BluebirdOps Core services" \
-		--url "https://github.com/bluebird-community/opennms" \
-		--maintainer "Maintainer <$(MAINTAINER_EMAIL)>" \
-		--depends jicmp \
-		--depends jicmp6 \
-		--depends jrrd2 \
-		--rpm-tag "Recommends: java-17-openjdk-devel" \
-		--rpm-tag "Suggests: postgresql-server >= 14.0" \
-		--rpm-tag "Suggests: iplike-pgsql14" \
-		--rpm-tag "Suggests: iplike-pgsql15" \
-		--rpm-tag "Suggests: iplike-pgsql16" \
-		--rpm-tag "Suggests: iplike-pgsql17" \
-		--rpm-tag "Suggests: iplike-pgsql18" \
-		--after-install packages/pkg-postinst-core.sh \
-		-C "$(BUILD_ROOT)/core"
+	ARCH="$(ARCH)" OPENNMS_VERSION="$(OPENNMS_VERSION)" PKG_RELEASE="$(PKG_RELEASE)" MAINTAINER_EMAIL="$(MAINTAINER_EMAIL)" \
+		nfpm package --packager rpm --config nfpm/nfpm-core.yaml --target "$(ARTIFACTS_DIR)/packages/core/"
 
 .PHONY: minion-pkg-buildroot
 minion-pkg-buildroot:
@@ -609,18 +581,8 @@ minion-pkg-deb: deps-packages minion-pkg-buildroot
 	@echo "Version:     " $(OPENNMS_VERSION)
 	@echo "Release:     " $(DEB_PKG_RELEASE)
 	@echo
-	fpm -s dir -t deb -p $(ARTIFACTS_DIR)/packages/minion/NAME_VERSION_ARCH_$(PKG_RELEASE).deb \
-		-n "bbo-minion" \
-		-v "$(OPENNMS_VERSION)-$(PKG_RELEASE)" \
-		--config-files /opt/minion/etc \
-		--description "BluebirdOps monitoring proxy service" \
-		--url "https://github.com/bluebird-community/opennms" \
-		--maintainer "Maintainer <$(MAINTAINER_EMAIL)>" \
-		--depends jicmp \
-		--depends jicmp6 \
-		--deb-recommends openjdk-17-jdk-headless \
-		--after-install packages/pkg-postinst-minion.sh \
-		-C "$(BUILD_ROOT)/minion"
+	ARCH="$(ARCH)" OPENNMS_VERSION="$(OPENNMS_VERSION)" PKG_RELEASE="$(PKG_RELEASE)" MAINTAINER_EMAIL="$(MAINTAINER_EMAIL)" \
+		nfpm package --packager deb --config nfpm/nfpm-minion.yaml --target "$(ARTIFACTS_DIR)/packages/minion/"
 
 .PHONY: minion-pkg-rpm
 minion-pkg-rpm: deps-packages minion-pkg-buildroot
@@ -629,18 +591,8 @@ minion-pkg-rpm: deps-packages minion-pkg-buildroot
 	@echo "Version:     " $(OPENNMS_VERSION)
 	@echo "Release:     " $(DEB_PKG_RELEASE)
 	@echo
-	fpm -s dir -t rpm -p $(ARTIFACTS_DIR)/packages/minion/NAME_VERSION_ARCH_$(PKG_RELEASE).rpm \
-		-n "bbo-minion" \
-		-v "$(OPENNMS_VERSION)_$(PKG_RELEASE)" \
-		--config-files /opt/minion/etc \
-		--description "BluebirdOps monitoring proxy service" \
-		--url "https://github.com/bluebird-community/opennms" \
-		--maintainer "Maintainer <$(MAINTAINER_EMAIL)>" \
-		--depends jicmp \
-		--depends jicmp6 \
-		--rpm-tag "Recommends: java-17-openjdk-devel" \
-		--after-install packages/pkg-postinst-minion.sh \
-		-C "$(BUILD_ROOT)/minion"
+	ARCH="$(ARCH)" OPENNMS_VERSION="$(OPENNMS_VERSION)" PKG_RELEASE="$(PKG_RELEASE)" MAINTAINER_EMAIL="$(MAINTAINER_EMAIL)" \
+		nfpm package --packager rpm --config nfpm/nfpm-minion.yaml --target "$(ARTIFACTS_DIR)/packages/minion/"
 
 .PHONY: sentinel-pkg-buildroot
 sentinel-pkg-buildroot:
@@ -673,16 +625,8 @@ sentinel-pkg-deb: deps-packages sentinel-pkg-buildroot
 	@echo "Version:     " $(OPENNMS_VERSION)
 	@echo "Release:     " $(DEB_PKG_RELEASE)
 	@echo
-	fpm -s dir -t deb -p $(ARTIFACTS_DIR)/packages/sentinel/NAME_VERSION_ARCH_$(PKG_RELEASE).deb \
-		-n "bbo-sentinel" \
-		-v "$(OPENNMS_VERSION)-$(PKG_RELEASE)" \
-		--config-files /opt/sentinel/etc \
-		--description "BluebirdOps services to horizontally scale backend workloads" \
-		--url "https://github.com/bluebird-community/opennms" \
-		--maintainer "Maintainer <$(MAINTAINER_EMAIL)>" \
-		--deb-recommends openjdk-17-jdk-headless \
-		--after-install packages/pkg-postinst-sentinel.sh \
-		-C "$(BUILD_ROOT)/sentinel"
+	ARCH="$(ARCH)" OPENNMS_VERSION="$(OPENNMS_VERSION)" PKG_RELEASE="$(PKG_RELEASE)" MAINTAINER_EMAIL="$(MAINTAINER_EMAIL)" \
+		nfpm package --packager deb --config nfpm/nfpm-sentinel.yaml --target "$(ARTIFACTS_DIR)/packages/sentinel/"
 
 .PHONY: sentinel-pkg-rpm
 sentinel-pkg-rpm: deps-packages sentinel-pkg-buildroot
@@ -691,16 +635,8 @@ sentinel-pkg-rpm: deps-packages sentinel-pkg-buildroot
 	@echo "Version:     " $(OPENNMS_VERSION)
 	@echo "Release:     " $(DEB_PKG_RELEASE)
 	@echo
-	fpm -s dir -t rpm -p $(ARTIFACTS_DIR)/packages/sentinel/NAME_VERSION_ARCH_$(PKG_RELEASE).rpm \
-		-n "bbo-sentinel" \
-		-v "$(OPENNMS_VERSION)_$(PKG_RELEASE)" \
-		--config-files /opt/sentinel/etc \
-		--description "BluebirdOps services to horizontally scale backend workloads" \
-		--url "https://github.com/bluebird-community/opennms" \
-		--maintainer "Maintainer <$(MAINTAINER_EMAIL)>" \
-		--rpm-tag "Recommends: java-17-openjdk-devel" \
-		--after-install packages/pkg-postinst-sentinel.sh \
-		-C "$(BUILD_ROOT)/sentinel"
+	ARCH="$(ARCH)" OPENNMS_VERSION="$(OPENNMS_VERSION)" PKG_RELEASE="$(PKG_RELEASE)" MAINTAINER_EMAIL="$(MAINTAINER_EMAIL)" \
+		nfpm package --packager rpm --config nfpm/nfpm-sentinel.yaml --target "$(ARTIFACTS_DIR)/packages/sentinel/"
 
 .PHON: all-pkgs
 all-pkgs: core-pkg-deb core-pkg-rpm minion-pkg-deb minion-pkg-rpm sentinel-pkg-deb sentinel-pkg-rpm

--- a/nfpm/nfpm-core.yaml
+++ b/nfpm/nfpm-core.yaml
@@ -1,0 +1,76 @@
+# nfpm config for the BluebirdOps Core package (bbo-core).
+# Consumed by `make core-pkg-deb` / `make core-pkg-rpm` (see Makefile), which
+# export OPENNMS_VERSION / PKG_RELEASE / ARCH / MAINTAINER_EMAIL before invoking
+# `nfpm package`. nfpm expands ${...} from the environment at load time.
+#
+# `version_schema: semver` is required: OPENNMS_VERSION carries `-SNAPSHOT` on
+# non-release builds and RPM forbids `-` in the Version field. semver parsing
+# relocates the SNAPSHOT prerelease so the RPM Version stays hyphen-free.
+#
+# recommends/suggests differ by packager (different distro package names), so
+# they live under `overrides:` rather than the shared top-level fields.
+name: bbo-core
+arch: ${ARCH}
+platform: linux
+version: ${OPENNMS_VERSION}
+version_schema: semver
+release: ${PKG_RELEASE}
+maintainer: "Maintainer <${MAINTAINER_EMAIL}>"
+description: BluebirdOps Core services
+homepage: https://github.com/bluebird-community/opennms
+
+depends:
+  - jicmp
+  - jicmp6
+  - jrrd2
+
+contents:
+  # Full payload tree assembled by the core-pkg-buildroot Makefile target.
+  - src: target/artifacts/buildroot/core/opt/opennms
+    dst: /opt/opennms
+  - src: target/artifacts/buildroot/core/usr/lib/systemd/system
+    dst: /usr/lib/systemd/system
+  # Empty runtime directories (no source files) — declared explicitly so nfpm
+  # includes them; postinstall chowns them to opennms:opennms.
+  - dst: /var/lib/opennms/rrd
+    type: dir
+    file_info: { mode: 0755 }
+  - dst: /var/lib/opennms/reports
+    type: dir
+    file_info: { mode: 0755 }
+  - dst: /var/log/opennms
+    type: dir
+    file_info: { mode: 0755 }
+  - dst: /var/lib/opennms/deploy
+    type: dir
+    file_info: { mode: 0755 }
+  # Mark the etc tree as configuration. Ordered after the broad /opt/opennms
+  # mapping so the config type wins for the overlapping paths (design D3/D4).
+  - src: target/artifacts/buildroot/core/opt/opennms/etc
+    dst: /opt/opennms/etc
+    type: config
+
+overrides:
+  deb:
+    recommends:
+      - openjdk-21-jre-headless
+    suggests:
+      - postgresql (>= 14.0)
+      - iplike-pgsql14
+      - iplike-pgsql15
+      - iplike-pgsql16
+      - iplike-pgsql17
+      - iplike-pgsql18
+  rpm:
+    recommends:
+      - java-21-openjdk-headless
+    suggests:
+      - postgresql-server >= 14.0
+      - iplike-pgsql14
+      - iplike-pgsql15
+      - iplike-pgsql16
+      - iplike-pgsql17
+      - iplike-pgsql18
+
+scripts:
+  postinstall: packages/pkg-postinst-core.sh

--- a/nfpm/nfpm-minion.yaml
+++ b/nfpm/nfpm-minion.yaml
@@ -1,0 +1,42 @@
+# nfpm config for the BluebirdOps Minion package (bbo-minion).
+# See nfpm-core.yaml for the shared conventions (env expansion, version_schema,
+# per-packager overrides).
+name: bbo-minion
+arch: ${ARCH}
+platform: linux
+version: ${OPENNMS_VERSION}
+version_schema: semver
+release: ${PKG_RELEASE}
+maintainer: "Maintainer <${MAINTAINER_EMAIL}>"
+description: BluebirdOps monitoring proxy service
+homepage: https://github.com/bluebird-community/opennms
+
+depends:
+  - jicmp
+  - jicmp6
+
+contents:
+  - src: target/artifacts/buildroot/minion/opt/minion
+    dst: /opt/minion
+  - src: target/artifacts/buildroot/minion/usr/lib/systemd/system
+    dst: /usr/lib/systemd/system
+  - dst: /var/log/minion
+    type: dir
+    file_info: { mode: 0755 }
+  - dst: /var/lib/minion/deploy
+    type: dir
+    file_info: { mode: 0755 }
+  - src: target/artifacts/buildroot/minion/opt/minion/etc
+    dst: /opt/minion/etc
+    type: config
+
+overrides:
+  deb:
+    recommends:
+      - openjdk-21-jre-headless
+  rpm:
+    recommends:
+      - java-21-openjdk-headless
+
+scripts:
+  postinstall: packages/pkg-postinst-minion.sh

--- a/nfpm/nfpm-sentinel.yaml
+++ b/nfpm/nfpm-sentinel.yaml
@@ -1,0 +1,38 @@
+# nfpm config for the BluebirdOps Sentinel package (bbo-sentinel).
+# See nfpm-core.yaml for the shared conventions (env expansion, version_schema,
+# per-packager overrides).
+name: bbo-sentinel
+arch: ${ARCH}
+platform: linux
+version: ${OPENNMS_VERSION}
+version_schema: semver
+release: ${PKG_RELEASE}
+maintainer: "Maintainer <${MAINTAINER_EMAIL}>"
+description: BluebirdOps services to horizontally scale backend workloads
+homepage: https://github.com/bluebird-community/opennms
+
+contents:
+  - src: target/artifacts/buildroot/sentinel/opt/sentinel
+    dst: /opt/sentinel
+  - src: target/artifacts/buildroot/sentinel/usr/lib/systemd/system
+    dst: /usr/lib/systemd/system
+  - dst: /var/log/sentinel
+    type: dir
+    file_info: { mode: 0755 }
+  - dst: /var/lib/sentinel/deploy
+    type: dir
+    file_info: { mode: 0755 }
+  - src: target/artifacts/buildroot/sentinel/opt/sentinel/etc
+    dst: /opt/sentinel/etc
+    type: config
+
+overrides:
+  deb:
+    recommends:
+      - openjdk-21-jre-headless
+  rpm:
+    recommends:
+      - java-21-openjdk-headless
+
+scripts:
+  postinstall: packages/pkg-postinst-sentinel.sh


### PR DESCRIPTION
## Summary

Migrates the Debian/RPM packaging pipeline from **fpm** to [**nfpm**](https://github.com/goreleaser/nfpm). Replaces the six imperative `fpm` invocations (core/minion/sentinel × deb/rpm) in the `Makefile` with three declarative nfpm configs, dropping the Ruby/fpm/`rpmbuild` toolchain in favour of a single pinned `nfpm` binary.

The `*-pkg-buildroot` Makefile targets and the `packages/pkg-postinst-*.sh` scripts are **reused unchanged** — only the package-construction step and its tool dependency change.

`[full-ci]` — this PR runs the full package + publish path so the acceptance gates below execute.

## What changed

| File | Change |
|---|---|
| `nfpm/nfpm-{core,minion,sentinel}.yaml` | **new** — per-artifact configs (contents mappings, `type: dir` for empty runtime dirs, `type: config` for `etc`, postinstall scripts) |
| `Makefile` | `deps-packages` → `nfpm` only (no `rpmbuild`); `ARCH ?= amd64`; six recipes call `nfpm package` |
| `.github/actions/setup-nfpm/action.yml` | **new** — composite action installing a pinned, SHA-256-verified nfpm 2.47.0 |
| `.github/workflows/main.yml` | `setup-nfpm` step added to the three package jobs |
| `.github/renovate.json` | custom manager to auto-bump the nfpm version |

## Notable improvements over the old fpm setup

- **No more `rpmbuild`** — nfpm builds RPMs natively in Go.
- **Version handling fixed** — fpm needed two hand-maintained version strings (deb `X-REL`, rpm `X_REL`). nfpm uses native `version` + `release` with `version_schema: semver`, so the `-SNAPSHOT` prerelease is correctly kept out of the RPM `Version` tag (which forbids `-`).
- **Java recommend corrected (intentional divergence from fpm).** The old fpm calls recommended **Java 17**, but the project is **Java 21 only**. JSPs are precompiled at build time (`opennms-webapp` `jspc` profile, `activeByDefault`) and the runtime JSP path uses the bundled Eclipse JDT compiler (ECJ), not `javac` — so a headless **JRE** suffices. Now recommends `openjdk-21-jre-headless` (deb) / `java-21-openjdk-headless` (rpm). This is the **one** intentional metadata difference vs the previous packages.

## Acceptance gates (run in this CI pass before merge)

- [ ] Metadata diff vs fpm output for all three artifacts (`dpkg-deb -I`/`-c`, `rpm -qip`/`-qlp`/`--scripts`) — must match except the documented Java recommend.
- [ ] Empty runtime dirs (`rrd`/`reports`/`logs`/`deploy`) present in `dpkg-deb -c` / `rpm -qlp`.
- [ ] `etc` tree marked conffile / `%config`.
- [ ] Install/upgrade/remove smoke on Debian + RHEL containers.
- [ ] Confirm supported distro baselines carry `openjdk-21-*` (older Debian 12 / Ubuntu 22.04 only ship `openjdk-17`; the weak recommend silently no-ops there).

## Deferred follow-ups (separate changes)

- Remove fpm/`rpmbuild` from the `quay.io/bluebird/java-builder` image (now unused by this pipeline).
- Evaluate `config|noreplace` for `etc` (don't clobber operator-edited configs on upgrade).
- Evaluate `arch: all`/noarch for the pure-Java payloads.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
