### PR TITLE
fix(build): restore topology-views jars in opennms-base-assembly

### DIFF
--- a/opennms-base-assembly/pom.xml
+++ b/opennms-base-assembly/pom.xml
@@ -1014,6 +1014,20 @@
       <artifactId>org.opennms.features.distributed.kv-store.json.postgres</artifactId>
       <version>${project.version}</version>
     </dependency>
+    <!-- Topology Views + Assets persistence (custom views; background
+         images and custom node icons referenced by views). -->
+    <dependency>
+      <groupId>org.opennms</groupId>
+      <artifactId>org.opennms.features.topology-views</artifactId>
+      <version>${project.version}</version>
+    </dependency>
+    <!-- Postgres BlobStore for topology-asset image bytes (only the no-op
+         blob store ships in lib otherwise). -->
+    <dependency>
+      <groupId>org.opennms.features.distributed</groupId>
+      <artifactId>org.opennms.features.distributed.kv-store.blob.postgres</artifactId>
+      <version>${project.version}</version>
+    </dependency>
     <dependency>
       <groupId>org.opennms.features</groupId>
       <artifactId>org.opennms.features.karaf-health</artifactId>


### PR DESCRIPTION
## Problem

The `main` push build [28625558250](https://github.com/Bluebird-Community/opennms/actions/runs/28625558250/job/84891244837) fails in `build-with-smoke-test`: every smoke test (`SinglePortFlowsIT`, `MenuHeaderIT`) times out because the `local/core:latest` container exits with code 1 during startup.

Root cause from the container log: JettyServer aborts with

```
Caused by: java.lang.NoClassDefFoundError: org/opennms/netmgt/topology/views/TopologyView
```

while Spring introspects `TopologyViewRestService` in the CXF REST context. `opennms-webapp-rest` depends on `org.opennms.features.topology-views` with `onmsLibScope=provided`, i.e. the jar must ship in `$OPENNMS_HOME/lib` via `opennms-base-assembly` — but the entry was missing.

It had been added in 4896b48dda1 ("Deploy topology-views on the runtime classpath", NMS-19874 smoke fixes, upstream PR #8562), and was silently dropped when resolving the `upstream/develop` merge 0c91e53e1a8 — its anchor context (the enlinkd block) no longer exists in our fork after the phase-6b module removals.

## Fix

Restore the two dependencies (`org.opennms.features.topology-views` and `kv-store.blob.postgres`) in `opennms-base-assembly/pom.xml`, byte-identical to the block on `upstream/develop` so future foundation merges reconcile cleanly.

## Verification

```
$ ./mvnw -q -f opennms-base-assembly/pom.xml dependency:tree -Dincludes=...
org.opennms:opennms-base-assembly:pom:37.0.2-SNAPSHOT
+- org.opennms:org.opennms.features.topology-views:jar:37.0.2-SNAPSHOT:compile
\- org.opennms.features.distributed:org.opennms.features.distributed.kv-store.blob.postgres:jar:37.0.2-SNAPSHOT:compile
```

Both are compile scope, so the generic `lib/` dependencySet in `src/assembly/daemon.xml` ships them. `make smoke` in this PR's CI is the end-to-end check.

🤖 Generated with [Claude Code](https://claude.com/claude-code)