### PR TITLE
test(ui): drop topology-map assertion from NodeActionsDropdown test

### DIFF
--- a/ui/tests/components/Nodes/NodeActionsDropdown.test.ts
+++ b/ui/tests/components/Nodes/NodeActionsDropdown.test.ts
@@ -18,8 +18,7 @@ describe('NodeActionsDropdown.vue', () => {
     const items = (wrapper.vm as any).items as Array<{ label: string }>
     expect(items[0].label).toBe('Info...')
     expect(items.map(i => i.label)).toContain('Events')
-    expect(items.map(i => i.label)).toContain('View Topology Map')
-    expect(items).toHaveLength(14) // Info + 13 links
+    expect(items).toHaveLength(13) // Info + 12 links
   })
 
   it('Info... command calls triggerNodeInfo with the node', () => {


### PR DESCRIPTION
## Problem

The `main` build [28686771411](https://github.com/Bluebird-Community/opennms/actions/runs/28686771411/job/85080882960) fails in **Build Web UI with pnpm including tests**:

```
FAIL tests/components/Nodes/NodeActionsDropdown.test.ts
AssertionError: expected [ Array(13) ] to include 'View Topology Map'
```

The `upstream/develop` merge (011b160c01f) clean-added upstream's new test file from the NMS-19620 PrimeVue Nodes migration (dc6d486661c). It asserts a 'View Topology Map' action and 14 menu items — but this fork removed the topology-map UI actions in phase 4 of the deprecated-code removal (26204be291b). The merged component correctly renders 13 items (Info + 12 links); only the test is wrong for this fork. No conflict marker surfaced this because the test file was a clean add on the upstream side.

Full investigation: `_bmad-output/implementation-artifacts/investigations/ui-nodeactions-topology-test-investigation.md` (in-repo, untracked).

## Fix

Test-only: drop the topology assertion and adjust the expected count to 13 (`Info + 12 links`). The component is unchanged.

## Verification

```
pnpm exec vitest run
Test Files  89 passed (89)
     Tests  2267 passed | 1 skipped (2268)
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)