### PR TITLE
fix(deps): pin jackson-annotations to its decoupled version (2.22)

### DIFF
--- a/container/features/src/main/resources/features-core.xml
+++ b/container/features/src/main/resources/features-core.xml
@@ -162,7 +162,7 @@
 
     <feature name="jackson-core" version="${jackson2Version}" description="Jackson 2 :: Base">
         <bundle dependency="true">mvn:com.fasterxml.jackson.core/jackson-databind/${jackson2Version}</bundle>
-        <bundle dependency="true">mvn:com.fasterxml.jackson.core/jackson-annotations/${jackson2Version}</bundle>
+        <bundle dependency="true">mvn:com.fasterxml.jackson.core/jackson-annotations/${jackson2AnnotationsVersion}</bundle>
         <bundle dependency="true">mvn:com.fasterxml.jackson.core/jackson-core/${jackson2Version}</bundle>
     </feature>
 

--- a/container/features/src/main/resources/features.xml
+++ b/container/features/src/main/resources/features.xml
@@ -1632,7 +1632,7 @@
     <feature name="opennms-newts-api" description="OpenNMS :: Newts API" version="${project.version}">
         <bundle dependency="true">mvn:com.fasterxml.jackson.core/jackson-core/${jackson2Version}</bundle>
         <bundle dependency="true">mvn:com.fasterxml.jackson.core/jackson-databind/${jackson2Version}</bundle>
-        <bundle dependency="true">mvn:com.fasterxml.jackson.core/jackson-annotations/${jackson2Version}</bundle>
+        <bundle dependency="true">mvn:com.fasterxml.jackson.core/jackson-annotations/${jackson2AnnotationsVersion}</bundle>
         <bundle dependency="true">mvn:com.google.guava/guava/${guavaVersion}</bundle>
         <bundle dependency="true">mvn:com.google.guava/failureaccess/${guavaFailureaccessVersion}</bundle>
         <bundle dependency="true">mvn:org.apache.commons/commons-jexl3/${commonsJexl3Version}</bundle>

--- a/container/karaf/pom.xml
+++ b/container/karaf/pom.xml
@@ -88,7 +88,7 @@
                     </bootFeatures>
                     <installedBundles>
                         <!-- override for security (see etc/overrides.properties) -->
-                        <bundle>mvn:com.fasterxml.jackson.core/jackson-annotations/${jackson2Version}</bundle>
+                        <bundle>mvn:com.fasterxml.jackson.core/jackson-annotations/${jackson2AnnotationsVersion}</bundle>
                         <bundle>mvn:com.fasterxml.jackson.core/jackson-core/${jackson2Version}</bundle>
                         <bundle>mvn:com.fasterxml.jackson.core/jackson-databind/${jackson2Version}</bundle>
                         <bundle>mvn:com.fasterxml.jackson.jaxrs/jackson-jaxrs-base/${jackson2Version}</bundle>

--- a/container/shared/pom.xml
+++ b/container/shared/pom.xml
@@ -126,7 +126,7 @@
                         <bundle>mvn:org.ops4j.pax.logging/pax-logging-log4j2/${paxLoggingVersion}</bundle>
                         <bundle>mvn:org.ops4j.pax.logging/pax-logging-logback/${paxLoggingVersion}</bundle>
 
-                        <bundle>mvn:com.fasterxml.jackson.core/jackson-annotations/${jackson2Version}</bundle>
+                        <bundle>mvn:com.fasterxml.jackson.core/jackson-annotations/${jackson2AnnotationsVersion}</bundle>
                         <bundle>mvn:com.fasterxml.jackson.core/jackson-core/${jackson2Version}</bundle>
                         <bundle>mvn:com.fasterxml.jackson.core/jackson-databind/${jackson2Version}</bundle>
 

--- a/dependencies/jackson2/pom.xml
+++ b/dependencies/jackson2/pom.xml
@@ -14,7 +14,7 @@
     <dependency>
       <groupId>com.fasterxml.jackson.core</groupId>
       <artifactId>jackson-annotations</artifactId>
-      <version>${jackson2Version}</version>
+      <version>${jackson2AnnotationsVersion}</version>
     </dependency>
     <dependency>
       <groupId>com.fasterxml.jackson.core</groupId>

--- a/features/container/sentinel/src/main/internal/features-processing.xml
+++ b/features/container/sentinel/src/main/internal/features-processing.xml
@@ -172,8 +172,8 @@
     <!-- jackson2 upgrades -->
     <bundle replacement="mvn:com.datastax.cassandra/cassandra-driver-core/${cassandraVersion}"
             originalUri="mvn:com.datastax.cassandra/cassandra-driver-core/[3,${cassandraVersion})" mode="maven" />
-    <bundle replacement="mvn:com.fasterxml.jackson.core/jackson-annotations/${jackson2Version}"
-            originalUri="mvn:com.fasterxml.jackson.core/jackson-annotations/[2,${jackson2Version})" mode="maven" />
+    <bundle replacement="mvn:com.fasterxml.jackson.core/jackson-annotations/${jackson2AnnotationsVersion}"
+            originalUri="mvn:com.fasterxml.jackson.core/jackson-annotations/[2,${jackson2AnnotationsVersion})" mode="maven" />
     <bundle replacement="mvn:com.fasterxml.jackson.core/jackson-core/${jackson2Version}"
             originalUri="mvn:com.fasterxml.jackson.core/jackson-core/[2,${jackson2Version})" mode="maven" />
     <bundle replacement="mvn:com.fasterxml.jackson.core/jackson-databind/${jackson2Version}"

--- a/pom.xml
+++ b/pom.xml
@@ -1817,6 +1817,8 @@
     <ipaddressVersion>5.5.0</ipaddressVersion>
     <jacksonVersion>1.9.14-atlassian-6</jacksonVersion>
     <jackson2Version>2.22.0</jackson2Version>
+    <!-- Since Jackson 2.20 jackson-annotations is released decoupled from the rest (no patch digit: 2.20, 2.21, 2.22) -->
+    <jackson2AnnotationsVersion>2.22</jackson2AnnotationsVersion>
     <jinjavaVersion>2.8.2</jinjavaVersion>
     <jmsApiVersion>2.0.1</jmsApiVersion>
     <snakeyamlVersion>2.3</snakeyamlVersion>
@@ -4388,7 +4390,7 @@
       <dependency>
         <groupId>com.fasterxml.jackson.core</groupId>
         <artifactId>jackson-annotations</artifactId>
-        <version>${jackson2Version}</version>
+        <version>${jackson2AnnotationsVersion}</version>
       </dependency>
       <dependency>
         <groupId>com.fasterxml.jackson.core</groupId>


### PR DESCRIPTION
## Problem

The `v38.0.1` release build ([run 28906038004](https://github.com/Bluebird-Community/opennms/actions/runs/28906038004)) failed during `Build and assemble from source`:

```
Could not resolve dependencies for project org.opennms.dependencies:jackson2-dependencies:pom:38.0.1
	Could not find artifact com.fasterxml.jackson.core:jackson-annotations:jar:2.22.0 in central
```

## Root cause

Dependabot commit `6acdcebdc33` bumped `jackson-databind` by editing the shared `jackson2Version` property (`2.16.2` → `2.22.0`). Every jackson artifact resolves against that one property — including `jackson-annotations`.

Since **Jackson 2.20**, `jackson-annotations` is released decoupled from `-core`/`-databind` and drops the patch digit: it ships as `2.20`, `2.21`, `2.22` (no `2.22.0`). So `jackson-annotations:2.22.0` does not exist in Central, while `jackson-databind:2.22.0` does.

## Fix

Introduce a dedicated `jackson2AnnotationsVersion` property (`2.22`) and point every `jackson-annotations` coordinate at it:

- root `pom.xml` `dependencyManagement`
- `dependencies/jackson2/pom.xml`
- `container/karaf/pom.xml` + `container/shared/pom.xml` `installedBundles`
- `container/features/src/main/resources/features.xml` + `features-core.xml`
- `features/container/sentinel/src/main/internal/features-processing.xml`

## Verification

```
./compile.pl -DskipTests=true --projects :jackson2-dependencies -am install
# Downloaded jackson-annotations/2.22/jackson-annotations-2.22.jar → BUILD SUCCESS
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)