### PR TITLE
fix(deps): drop netty-codec-base, absent from netty 4.1.x

### DIFF
--- a/container/features/src/main/resources/features-core.xml
+++ b/container/features/src/main/resources/features-core.xml
@@ -304,7 +304,6 @@ org.jolokia.authMode=jaas
         <bundle>mvn:org.opennms.dependencies/eclipse-npn-alpn/${project.version}</bundle>
 
         <bundle>mvn:io.netty/netty-buffer/${netty4Version}</bundle>
-        <bundle dependency="true">mvn:io.netty/netty-codec-base/${netty4Version}</bundle>
         <bundle>mvn:io.netty/netty-codec/${netty4Version}</bundle>
         <bundle>mvn:io.netty/netty-codec-dns/${netty4Version}</bundle>
         <bundle dependency="true">wrap:mvn:io.netty/netty-common/${netty4Version}$overwrite=merge&amp;Import-Package=com.oracle.svm.core.annotate;resolution:=optional</bundle>

--- a/pom.xml
+++ b/pom.xml
@@ -4872,11 +4872,6 @@
       </dependency>
       <dependency>
         <groupId>io.netty</groupId>
-        <artifactId>netty-codec-base</artifactId>
-        <version>${netty4Version}</version>
-      </dependency>
-      <dependency>
-        <groupId>io.netty</groupId>
         <artifactId>netty-codec-xml</artifactId>
         <version>${netty4Version}</version>
       </dependency>


### PR DESCRIPTION
## Problem

After merging #161 (jackson fix), the `main` build ([run 28940475757](https://github.com/Bluebird-Community/opennms/actions/runs/28940475757)) got past the jackson resolution but failed later in the Karaf assembly:

```
Error resolving feature netty/4.1.135.Final: Can't resolve artifact
mvn:io.netty/netty-codec-base/4.1.135.Final
  Could not find artifact io.netty:netty-codec-base:jar:4.1.135.Final
```

## Root cause

`netty-codec-base` was introduced when netty split `netty-codec` in the **4.2.x** line — it does not exist for 4.1.x. `NMS-19779` added the dependencyManagement entry and the Karaf feature bundle while netty was on `4.2.13.Final`. A later Dependabot `netty-handler` bump (`e0179108488`) moved the shared `netty4Version` back to `4.1.135.Final` and left the now-invalid coordinate behind.

## Fix

No module declares a dependency on `netty-codec-base`; it was only a dependencyManagement version pin plus one bundle in the `netty` Karaf feature. On 4.1.x the codec classes ship in `netty-codec` (still listed). Drop both `netty-codec-base` references.

## Verification

- `grep` confirms no remaining `netty-codec-base` references in source.
- Root pom validates.
- Full Karaf-assembly resolution verified by the post-merge `main` CI (the step that was failing).

🤖 Generated with [Claude Code](https://claude.com/claude-code)