### PR TITLE
fix(deps): use jackson2AnnotationsVersion in remaining module pins

### DIFF
--- a/e2e-tests/pom.xml
+++ b/e2e-tests/pom.xml
@@ -406,7 +406,7 @@
       <dependency>
         <groupId>com.fasterxml.jackson.core</groupId>
         <artifactId>jackson-annotations</artifactId>
-        <version>${jackson2Version}</version>
+        <version>${jackson2AnnotationsVersion}</version>
       </dependency>
       <dependency>
         <groupId>com.fasterxml.jackson.core</groupId>

--- a/integration-tests/config/pom.xml
+++ b/integration-tests/config/pom.xml
@@ -249,7 +249,7 @@
     <dependency>
       <groupId>com.fasterxml.jackson.core</groupId>
       <artifactId>jackson-annotations</artifactId>
-      <version>${jackson2Version}</version>
+      <version>${jackson2AnnotationsVersion}</version>
     </dependency>
     <dependency>
       <groupId>com.fasterxml.jackson.core</groupId>

--- a/opennms-full-assembly/pom.xml
+++ b/opennms-full-assembly/pom.xml
@@ -216,7 +216,7 @@
                 <artifactItem>
                   <groupId>com.fasterxml.jackson.core</groupId>
                   <artifactId>jackson-annotations</artifactId>
-                  <version>${jackson2Version}</version>
+                  <version>${jackson2AnnotationsVersion}</version>
                   <outputDirectory>${project.build.directory}/hawtio-webapp/WEB-INF/lib</outputDirectory>
                 </artifactItem>
                 <artifactItem>


### PR DESCRIPTION
## Problem

After #161, the `main` build got past the dependencyManagement/feature references but failed on a module that pins `jackson-annotations` explicitly:

```
Could not resolve dependencies for project org.opennms:org.opennms.integration-tests.config
  Could not find artifact com.fasterxml.jackson.core:jackson-annotations:jar:2.22.0
```

## Root cause

#161 switched `jackson-annotations` to the decoupled `jackson2AnnotationsVersion` (`2.22`) in root `dependencyManagement` and the Karaf features. But three module POMs declared their own `<version>${jackson2Version}</version>` on `jackson-annotations`, which overrides the managed version and re-requests the non-existent `2.22.0`.

## Fix

Point the three remaining explicit pins at `jackson2AnnotationsVersion`:
- `integration-tests/config/pom.xml`
- `e2e-tests/pom.xml`
- `opennms-full-assembly/pom.xml`

A repo-wide sweep confirms these were the last source references still on `${jackson2Version}` for `jackson-annotations`.

## Verification

```
./compile.pl --projects :org.opennms.integration-tests.config -am dependency:resolve
#  com.fasterxml.jackson.core:jackson-annotations:jar:2.22:compile ✓
```

Full assemble verified by post-merge `main` CI.

🤖 Generated with [Claude Code](https://claude.com/claude-code)