### PR TITLE
fix(deps): define jackson2AnnotationsVersion in e2e-tests reactor

### DIFF
--- a/e2e-tests/pom.xml
+++ b/e2e-tests/pom.xml
@@ -52,6 +52,8 @@
     <groovyVersion>3.0.21</groovyVersion>
     <frontendPluginVersion>1.15.1</frontendPluginVersion>
     <jackson2Version>2.22.0</jackson2Version>
+    <!-- Since Jackson 2.20 jackson-annotations is released decoupled from the rest (no patch digit: 2.20, 2.21, 2.22) -->
+    <jackson2AnnotationsVersion>2.22</jackson2AnnotationsVersion>
     <jersey.version>2.46</jersey.version>
     <jestVersion>5.3.4</jestVersion>
     <junit5Version>5.9.2</junit5Version>


### PR DESCRIPTION
## Problem

After #163 the assemble step passed and the quick smoke test finally ran, but failed resolving `e2e-tests` dependencies:

```
dependency: com.fasterxml.jackson.core:jackson-annotations:jar:${jackson2AnnotationsVersion} (compile)
  Could not find artifact ...jackson-annotations:jar:${jackson2AnnotationsVersion}
```

## Root cause

The smoke test builds `e2e-tests` as a **standalone** Maven project (`mvn --file e2e-tests/pom.xml`) that does not inherit the root OpenNMS POM. #163 pointed its `jackson-annotations` dependency at `${jackson2AnnotationsVersion}`, but that property was only defined in the root POM — so in the e2e-tests reactor it stayed literal.

## Fix

`e2e-tests/pom.xml` already defines its own `jackson2Version`; add a matching `jackson2AnnotationsVersion` (`2.22`) beside it.

## Verification

```
./mvnw -f e2e-tests/pom.xml -N help:evaluate -Dexpression=jackson2AnnotationsVersion -DforceStdout
2.22
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)