### PR TITLE
fix(deps): use jackson2AnnotationsVersion in Karaf runtime configs

### DIFF
--- a/container/features/src/main/resources/overrides.properties
+++ b/container/features/src/main/resources/overrides.properties
@@ -4,7 +4,7 @@ mvn:org.ops4j.pax.logging/pax-logging-log4j2/${paxLoggingVersion};range=[1.0,2.0
 mvn:org.ops4j.pax.logging/pax-logging-logback/${paxLoggingVersion};range=[1.0,2.0)
 mvn:org.apache.commons/commons-collections4/${commonsCollections4Version}
 mvn:com.datastax.cassandra/cassandra-driver-core/${cassandraVersion}
-mvn:com.fasterxml.jackson.core/jackson-annotations/${jackson2Version}
+mvn:com.fasterxml.jackson.core/jackson-annotations/${jackson2AnnotationsVersion}
 mvn:com.fasterxml.jackson.core/jackson-core/${jackson2Version}
 mvn:com.fasterxml.jackson.core/jackson-databind/${jackson2Version}
 mvn:org.apache.qpid/proton-j/0.34.0

--- a/container/shared/src/main/filtered-resources/etc/overrides.properties
+++ b/container/shared/src/main/filtered-resources/etc/overrides.properties
@@ -4,7 +4,7 @@ mvn:org.ops4j.pax.logging/pax-logging-log4j2/${paxLoggingVersion};range=[1.0,2.0
 mvn:org.ops4j.pax.logging/pax-logging-logback/${paxLoggingVersion};range=[1.0,2.0)
 mvn:org.apache.commons/commons-collections4/${commonsCollections4Version}
 mvn:com.datastax.cassandra/cassandra-driver-core/${cassandraVersion}
-mvn:com.fasterxml.jackson.core/jackson-annotations/${jackson2Version}
+mvn:com.fasterxml.jackson.core/jackson-annotations/${jackson2AnnotationsVersion}
 mvn:com.fasterxml.jackson.core/jackson-core/${jackson2Version}
 mvn:com.fasterxml.jackson.core/jackson-databind/${jackson2Version}
 mvn:org.apache.qpid/proton-j/0.34.0
@@ -104,7 +104,7 @@ mvn:io.netty/netty-transport-native-epoll/${netty4Version}
 mvn:io.netty/netty-transport-native-unix-common/${netty4Version}
 mvn:io.netty/netty-transport-native-kqueue/${netty4Version}
 
-mvn:com.fasterxml.jackson.core/jackson-annotations/${jackson2Version}
+mvn:com.fasterxml.jackson.core/jackson-annotations/${jackson2AnnotationsVersion}
 mvn:com.fasterxml.jackson.core/jackson-databind/${jackson2Version}
 mvn:com.fasterxml.jackson.core/jackson-core/${jackson2Version}
 

--- a/container/shared/src/main/filtered-resources/etc/startup.properties
+++ b/container/shared/src/main/filtered-resources/etc/startup.properties
@@ -28,7 +28,7 @@ mvn\:org.apache.felix/org.apache.felix.fileinstall/${felixFileinstallVersion} = 
 # OPENNMS: Pre-start jackson 2.x before features.core so hawtio-log-osgi can satisfy its
 # com.fasterxml.jackson.annotation import even when hawtio's own jackson 2.14.1 dependency
 # is blacklisted (see container/shared/pom.xml <blacklistedBundles>).
-mvn\:com.fasterxml.jackson.core/jackson-annotations/${jackson2Version} = 13
+mvn\:com.fasterxml.jackson.core/jackson-annotations/${jackson2AnnotationsVersion} = 13
 mvn\:com.fasterxml.jackson.core/jackson-core/${jackson2Version} = 13
 mvn\:com.fasterxml.jackson.core/jackson-databind/${jackson2Version} = 14
 


### PR DESCRIPTION
## Problem

After #164 the assemble step passed and the quick smoke test actually ran the containerized ITs — but the OpenNMS core container failed to start:

```
KarafStartupMonitor: It seems Karaf can't be started properly. This is bad, will fail startup.
Error resolving artifact com.fasterxml.jackson.core:jackson-annotations:jar:2.22.0:
  Could not find artifact ...jackson-annotations:jar:2.22.0
```

## Root cause

The Karaf **runtime** bundle overrides and the startup bundle list are Maven-filtered from the shared `jackson2Version` property, so they baked `2.22.0` into the assembled product and the running container tried to resolve the non-existent `jackson-annotations:2.22.0`:

- `container/shared/src/main/filtered-resources/etc/overrides.properties`
- `container/features/src/main/resources/overrides.properties`
- `container/shared/src/main/filtered-resources/etc/startup.properties`

## Fix

Point the `jackson-annotations` entries at `jackson2AnnotationsVersion` (`2.22`). `jackson-core`/`jackson-databind` stay on `jackson2Version` (`2.22.0` exists for those).

A repo-wide sweep across **all** file types confirms no source reference to `jackson-annotations` remains tied to `jackson2Version`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)