### PR TITLE
feat(flows): ClickHouse read path — field, host & conversation dimensions

### DIFF
--- a/features/flows/clickhouse/src/main/java/org/opennms/netmgt/flows/clickhouse/ClickhouseFlowQueryService.java
+++ b/features/flows/clickhouse/src/main/java/org/opennms/netmgt/flows/clickhouse/ClickhouseFlowQueryService.java
@@ -199,7 +199,8 @@ public class ClickhouseFlowQueryService implements FlowQueryService {
         // selected[bucket] = {ingressSum, egressSum}, only tracked when we need the "Other" residual.
         final Map<Long, double[]> selectedByBucket = includeOther ? new HashMap<>() : null;
 
-        for (final GenericRecord r : client.queryAll(seriesSql(w, applications, range[0], range[1], step))) {
+        final String appFilter = "application IN (" + quoteAll(applications) + ")";
+        for (final GenericRecord r : client.queryAll(seriesSql("application", appFilter, w, range[0], range[1], step))) {
             final boolean ingress = "ingress".equals(r.getString("d"));
             final long bucket = r.getLong("b");
             final double bytes = r.getDouble("bytes");
@@ -210,7 +211,7 @@ public class ClickhouseFlowQueryService implements FlowQueryService {
         }
 
         if (includeOther) {
-            for (final GenericRecord r : client.queryAll(seriesSql(w, null, range[0], range[1], step))) {
+            for (final GenericRecord r : client.queryAll(seriesSql(null, null, w, range[0], range[1], step))) {
                 final boolean ingress = "ingress".equals(r.getString("d"));
                 final long bucket = r.getLong("b");
                 final double grand = r.getDouble("bytes");
@@ -234,17 +235,18 @@ public class ClickhouseFlowQueryService implements FlowQueryService {
     }
 
     /**
-     * Build the proportional-series SQL. When {@code applications} is null the result is grouped by
-     * direction/bucket only (the grand total used for the "Other" residual); otherwise it is grouped
-     * by application/direction/bucket and restricted to those applications.
+     * Build the proportional-series SQL for an arbitrary entity column (D-PROPORTION). When
+     * {@code entityColumn} is null the result is grouped by direction/bucket only (the grand total
+     * used for the "Other" residual); otherwise it is grouped by {@code toString(entityColumn)} /
+     * direction / bucket. {@code entityFilter} (may be null/empty) is ANDed into the WHERE clause.
      */
-    private String seriesSql(final String whereClause, final Set<String> applications,
+    private String seriesSql(final String entityColumn, final String entityFilter, final String whereClause,
                              final long start, final long end, final long step) {
-        final boolean byApp = applications != null;
-        final String innerEntity = byApp ? "application, " : "";   // raw column in the innermost select
-        final String midEntity = byApp ? "application AS e, " : ""; // aliased in the middle select
-        final String entityGroup = byApp ? "e, " : "";
-        final String appFilter = byApp ? " AND application IN (" + quoteAll(applications) + ")" : "";
+        final boolean byEntity = entityColumn != null;
+        final String innerEntity = byEntity ? entityColumn + ", " : "";                 // raw column, innermost select
+        final String midEntity = byEntity ? "toString(" + entityColumn + ") AS e, " : ""; // stringified in the middle
+        final String entityGroup = byEntity ? "e, " : "";
+        final String appFilter = (entityFilter != null && !entityFilter.isEmpty()) ? " AND " + entityFilter : "";
         return "WITH " + start + " AS q_start, " + end + " AS q_end, " + step + " AS q_step "
                 + "SELECT " + entityGroup + "d, b, sum(share) AS bytes FROM ("
                 + "  SELECT " + midEntity + "direction AS d, (q_start + i * q_step) AS b,"
@@ -338,18 +340,47 @@ public class ClickhouseFlowQueryService implements FlowQueryService {
     @Override
     public CompletableFuture<List<String>> getFieldValues(final LimitedCardinalityField field,
                                                           final List<Filter> filters) {
-        throw todo("getFieldValues");
+        final String col = fieldColumn(field);
+        final String sql = "SELECT DISTINCT toString(" + col + ") AS v FROM " + table
+                + " WHERE " + where(filters) + " ORDER BY " + col;
+        final List<String> values = client.queryAll(sql).stream()
+                .map(r -> r.getString("v"))
+                .collect(Collectors.toList());
+        return CompletableFuture.completedFuture(values);
     }
 
     @Override
     public CompletableFuture<List<TrafficSummary<String>>> getFieldSummaries(final LimitedCardinalityField field,
                                                                              final List<Filter> filters) {
-        throw todo("getFieldSummaries");
+        final String col = fieldColumn(field);
+        // A limited-cardinality field returns every value, so there is no top-N / "Other".
+        final String sql = "SELECT toString(" + col + ") AS e,"
+                + " sumIf(bytes, direction = 'ingress') AS bin,"
+                + " sumIf(bytes, direction = 'egress') AS bout"
+                + " FROM " + table + " WHERE " + where(filters) + " GROUP BY " + col + " ORDER BY " + col;
+        return CompletableFuture.completedFuture(summariesFrom(client.queryAll(sql)));
     }
 
     @Override
     public CompletableFuture<Table<Directional<String>, Long, Double>> getFieldSeries(
             final LimitedCardinalityField field, final long step, final List<Filter> filters) {
-        throw todo("getFieldSeries");
+        final String col = fieldColumn(field);
+        final long[] range = timeRange(filters);
+        final Table<Directional<String>, Long, Double> table = HashBasedTable.create();
+        for (final GenericRecord r : client.queryAll(seriesSql(col, null, where(filters), range[0], range[1], step))) {
+            table.put(new Directional<>(r.getString("e"), "ingress".equals(r.getString("d"))),
+                      r.getLong("b"), r.getDouble("bytes"));
+        }
+        return CompletableFuture.completedFuture(table);
+    }
+
+    /** Map a {@link LimitedCardinalityField} to its ClickHouse column. */
+    private static String fieldColumn(final LimitedCardinalityField field) {
+        switch (field) {
+            case DSCP:
+                return "dscp";
+            default:
+                throw new IllegalArgumentException("Unsupported field: " + field);
+        }
     }
 }

--- a/features/flows/clickhouse/src/main/java/org/opennms/netmgt/flows/clickhouse/ClickhouseFlowQueryService.java
+++ b/features/flows/clickhouse/src/main/java/org/opennms/netmgt/flows/clickhouse/ClickhouseFlowQueryService.java
@@ -200,7 +200,7 @@ public class ClickhouseFlowQueryService implements FlowQueryService {
         final Map<Long, double[]> selectedByBucket = includeOther ? new HashMap<>() : null;
 
         final String appFilter = "application IN (" + quoteAll(applications) + ")";
-        for (final GenericRecord r : client.queryAll(seriesSql("application", appFilter, w, range[0], range[1], step))) {
+        for (final GenericRecord r : client.queryAll(seriesSql(this.table, "application", appFilter, w, range[0], range[1], step))) {
             final boolean ingress = "ingress".equals(r.getString("d"));
             final long bucket = r.getLong("b");
             final double bytes = r.getDouble("bytes");
@@ -211,7 +211,7 @@ public class ClickhouseFlowQueryService implements FlowQueryService {
         }
 
         if (includeOther) {
-            for (final GenericRecord r : client.queryAll(seriesSql(null, null, w, range[0], range[1], step))) {
+            for (final GenericRecord r : client.queryAll(seriesSql(this.table, null, null, w, range[0], range[1], step))) {
                 final boolean ingress = "ingress".equals(r.getString("d"));
                 final long bucket = r.getLong("b");
                 final double grand = r.getDouble("bytes");
@@ -240,8 +240,8 @@ public class ClickhouseFlowQueryService implements FlowQueryService {
      * used for the "Other" residual); otherwise it is grouped by {@code toString(entityColumn)} /
      * direction / bucket. {@code entityFilter} (may be null/empty) is ANDed into the WHERE clause.
      */
-    private String seriesSql(final String entityColumn, final String entityFilter, final String whereClause,
-                             final long start, final long end, final long step) {
+    private String seriesSql(final String fromExpr, final String entityColumn, final String entityFilter,
+                             final String whereClause, final long start, final long end, final long step) {
         final boolean byEntity = entityColumn != null;
         final String innerEntity = byEntity ? entityColumn + ", " : "";                 // raw column, innermost select
         final String midEntity = byEntity ? "toString(" + entityColumn + ") AS e, " : ""; // stringified in the middle
@@ -260,7 +260,7 @@ public class ClickhouseFlowQueryService implements FlowQueryService {
                 + "      greatest(toUnixTimestamp64Milli(first_switched), q_start) AS lo,"
                 + "      least(toUnixTimestamp64Milli(last_switched), q_end - 1) AS hi,"
                 + "      if(hi >= lo, range(toUInt64(intDiv(lo - q_start, q_step)), toUInt64(intDiv(hi - q_start, q_step)) + 1), emptyArrayUInt64()) AS idxs"
-                + "    FROM " + table + " WHERE " + whereClause + appFilter + " AND direction IN ('ingress', 'egress')"
+                + "    FROM " + fromExpr + " WHERE " + whereClause + appFilter + " AND direction IN ('ingress', 'egress')"
                 + "  ) ARRAY JOIN idxs AS i"
                 + ") WHERE share > 0 GROUP BY " + entityGroup + "d, b ORDER BY " + entityGroup + "d, b";
     }
@@ -310,31 +310,147 @@ public class ClickhouseFlowQueryService implements FlowQueryService {
 
     @Override
     public CompletableFuture<List<String>> getHosts(final String regex, final long limit, final List<Filter> filters) {
-        throw todo("getHosts");
+        final String sql = "SELECT DISTINCT toString(host) AS e FROM " + hostUnion(where(filters))
+                + " WHERE match(toString(host), " + quote(regex) + ") ORDER BY e LIMIT " + limit;
+        final List<String> hosts = client.queryAll(sql).stream()
+                .map(r -> r.getString("e")).collect(Collectors.toList());
+        return CompletableFuture.completedFuture(hosts);
     }
 
     @Override
     public CompletableFuture<List<TrafficSummary<Host>>> getTopNHostSummaries(
             final int n, final boolean includeOther, final List<Filter> filters) {
-        throw todo("getTopNHostSummaries");
+        final String w = where(filters);
+        final String sql = hostSummarySelect(w) + " GROUP BY host ORDER BY (bin + bout) DESC, e LIMIT " + n;
+        final List<TrafficSummary<Host>> summaries = hostSummariesFrom(client.queryAll(sql));
+        if (includeOther) {
+            appendOtherHost(summaries, w);
+        }
+        return CompletableFuture.completedFuture(summaries);
     }
 
     @Override
     public CompletableFuture<List<TrafficSummary<Host>>> getHostSummaries(
             final Set<String> hosts, final boolean includeOther, final List<Filter> filters) {
-        throw todo("getHostSummaries");
+        if (hosts.isEmpty()) {
+            return CompletableFuture.completedFuture(new ArrayList<>());
+        }
+        final String w = where(filters);
+        final String sql = hostSummarySelect(w) + " WHERE toString(host) IN (" + quoteAll(hosts) + ")"
+                + " GROUP BY host ORDER BY e";
+        final List<TrafficSummary<Host>> summaries = hostSummariesFrom(client.queryAll(sql));
+        if (includeOther) {
+            appendOtherHost(summaries, w);
+        }
+        return CompletableFuture.completedFuture(summaries);
     }
 
     @Override
     public CompletableFuture<Table<Directional<Host>, Long, Double>> getHostSeries(
             final Set<String> hosts, final long step, final boolean includeOther, final List<Filter> filters) {
-        throw todo("getHostSeries");
+        return CompletableFuture.completedFuture(hostSeries(hosts, step, includeOther, filters));
     }
 
     @Override
     public CompletableFuture<Table<Directional<Host>, Long, Double>> getTopNHostSeries(
             final int n, final long step, final boolean includeOther, final List<Filter> filters) {
-        throw todo("getTopNHostSeries");
+        return CompletableFuture.completedFuture(hostSeries(topNHosts(n, where(filters)), step, includeOther, filters));
+    }
+
+    // --- host helpers -----------------------------------------------------
+
+    /** src+dst endpoints unioned so each flow contributes to both its source and destination host. */
+    private String hostUnion(final String whereClause) {
+        return "(SELECT src_addr AS host, src_hostname AS host_hostname, direction, bytes, first_switched, last_switched"
+                + " FROM " + table + " WHERE " + whereClause
+                + " UNION ALL SELECT dst_addr AS host, dst_hostname AS host_hostname, direction, bytes, first_switched, last_switched"
+                + " FROM " + table + " WHERE " + whereClause + ")";
+    }
+
+    private String hostSummarySelect(final String whereClause) {
+        return "SELECT toString(host) AS e, anyIf(host_hostname, host_hostname != '') AS hn,"
+                + " sumIf(bytes, direction = 'ingress') AS bin, sumIf(bytes, direction = 'egress') AS bout"
+                + " FROM " + hostUnion(whereClause);
+    }
+
+    private static List<TrafficSummary<Host>> hostSummariesFrom(final List<GenericRecord> rows) {
+        final List<TrafficSummary<Host>> out = new ArrayList<>(rows.size());
+        for (final GenericRecord r : rows) {
+            out.add(TrafficSummary.from(host(r.getString("e"), r.getString("hn")))
+                    .withBytes(r.getLong("bin"), r.getLong("bout")).build());
+        }
+        return out;
+    }
+
+    private void appendOtherHost(final List<TrafficSummary<Host>> summaries, final String whereClause) {
+        final List<GenericRecord> grand = client.queryAll(
+                "SELECT sumIf(bytes, direction = 'ingress') AS bin, sumIf(bytes, direction = 'egress') AS bout FROM "
+                        + hostUnion(whereClause));
+        final long grandIn = grand.isEmpty() ? 0L : grand.get(0).getLong("bin");
+        final long grandOut = grand.isEmpty() ? 0L : grand.get(0).getLong("bout");
+        final long otherIn = grandIn - summaries.stream().mapToLong(TrafficSummary::getBytesIn).sum();
+        final long otherOut = grandOut - summaries.stream().mapToLong(TrafficSummary::getBytesOut).sum();
+        if (otherIn > 0 || otherOut > 0) {
+            summaries.add(TrafficSummary.from(Host.forOther().build()).withBytes(otherIn, otherOut).build());
+        }
+    }
+
+    private Set<String> topNHosts(final int n, final String whereClause) {
+        final String sql = "SELECT toString(host) AS e FROM " + hostUnion(whereClause)
+                + " GROUP BY host ORDER BY sum(bytes) DESC, e LIMIT " + n;
+        return client.queryAll(sql).stream().map(r -> r.getString("e"))
+                .collect(Collectors.toCollection(LinkedHashSet::new));
+    }
+
+    private Table<Directional<Host>, Long, Double> hostSeries(final Set<String> hosts, final long step,
+                                                              final boolean includeOther, final List<Filter> filters) {
+        final Table<Directional<Host>, Long, Double> table = HashBasedTable.create();
+        if (hosts.isEmpty()) {
+            return table;
+        }
+        final long[] range = timeRange(filters);
+        final String w = where(filters);
+        final Map<String, String> hostnames = resolveHostHostnames(hosts, w);
+        final Map<Long, double[]> selectedByBucket = includeOther ? new HashMap<>() : null;
+        final String filter = "toString(host) IN (" + quoteAll(hosts) + ")";
+        for (final GenericRecord r : client.queryAll(seriesSql(hostUnion(w), "host", filter, "1 = 1", range[0], range[1], step))) {
+            final boolean ingress = "ingress".equals(r.getString("d"));
+            final long bucket = r.getLong("b");
+            final double bytes = r.getDouble("bytes");
+            table.put(new Directional<>(host(r.getString("e"), hostnames.get(r.getString("e"))), ingress), bucket, bytes);
+            if (includeOther) {
+                selectedByBucket.computeIfAbsent(bucket, k -> new double[2])[ingress ? 0 : 1] += bytes;
+            }
+        }
+        if (includeOther) {
+            for (final GenericRecord r : client.queryAll(seriesSql(hostUnion(w), null, null, "1 = 1", range[0], range[1], step))) {
+                final boolean ingress = "ingress".equals(r.getString("d"));
+                final long bucket = r.getLong("b");
+                final double other = r.getDouble("bytes")
+                        - selectedByBucket.getOrDefault(bucket, new double[2])[ingress ? 0 : 1];
+                if (Math.abs(other) > 1e-9) {
+                    table.put(new Directional<>(Host.forOther().build(), ingress), bucket, other);
+                }
+            }
+        }
+        return table;
+    }
+
+    private Map<String, String> resolveHostHostnames(final Set<String> hosts, final String whereClause) {
+        final Map<String, String> map = new HashMap<>();
+        final String sql = "SELECT toString(host) AS e, anyIf(host_hostname, host_hostname != '') AS hn FROM "
+                + hostUnion(whereClause) + " WHERE toString(host) IN (" + quoteAll(hosts) + ") GROUP BY host";
+        for (final GenericRecord r : client.queryAll(sql)) {
+            final String hn = r.getString("hn");
+            if (hn != null && !hn.isEmpty()) {
+                map.put(r.getString("e"), hn);
+            }
+        }
+        return map;
+    }
+
+    private static Host host(final String ip, final String hostname) {
+        return (hostname != null && !hostname.isEmpty()) ? new Host(ip, hostname) : new Host(ip);
     }
 
     @Override
@@ -367,7 +483,7 @@ public class ClickhouseFlowQueryService implements FlowQueryService {
         final String col = fieldColumn(field);
         final long[] range = timeRange(filters);
         final Table<Directional<String>, Long, Double> table = HashBasedTable.create();
-        for (final GenericRecord r : client.queryAll(seriesSql(col, null, where(filters), range[0], range[1], step))) {
+        for (final GenericRecord r : client.queryAll(seriesSql(this.table, col, null, where(filters), range[0], range[1], step))) {
             table.put(new Directional<>(r.getString("e"), "ingress".equals(r.getString("d"))),
                       r.getLong("b"), r.getDouble("bytes"));
         }

--- a/features/flows/clickhouse/src/main/java/org/opennms/netmgt/flows/clickhouse/ClickhouseFlowQueryService.java
+++ b/features/flows/clickhouse/src/main/java/org/opennms/netmgt/flows/clickhouse/ClickhouseFlowQueryService.java
@@ -18,6 +18,7 @@ import java.util.concurrent.CompletableFuture;
 import java.util.stream.Collectors;
 
 import org.opennms.netmgt.flows.api.Conversation;
+import org.opennms.netmgt.flows.api.ConversationKey;
 import org.opennms.netmgt.flows.api.Directional;
 import org.opennms.netmgt.flows.api.FlowQueryService;
 import org.opennms.netmgt.flows.api.Host;
@@ -25,6 +26,7 @@ import org.opennms.netmgt.flows.api.LimitedCardinalityField;
 import org.opennms.netmgt.flows.api.TrafficSummary;
 import org.opennms.netmgt.flows.filter.api.Filter;
 import org.opennms.netmgt.flows.filter.api.TimeRangeFilter;
+import org.opennms.netmgt.flows.processing.ConversationKeyUtils;
 
 import com.clickhouse.client.api.Client;
 import com.clickhouse.client.api.query.GenericRecord;
@@ -160,13 +162,6 @@ public class ClickhouseFlowQueryService implements FlowQueryService {
         return values.stream().map(ClickhouseFlowQueryService::quote).collect(Collectors.joining(", "));
     }
 
-    private static UnsupportedOperationException todo(final String method) {
-        return new UnsupportedOperationException(
-                "ClickhouseFlowQueryService." + method + " is not yet implemented (phase 3 continuation).");
-    }
-
-    // --- not yet implemented (phase 3 continuation) -----------------------
-
     @Override
     public CompletableFuture<Table<Directional<String>, Long, Double>> getApplicationSeries(
             final Set<String> applications, final long step, final boolean includeOther, final List<Filter> filters) {
@@ -281,31 +276,175 @@ public class ClickhouseFlowQueryService implements FlowQueryService {
                                                             final String lowerIPPattern, final String upperIPPattern,
                                                             final String applicationPattern, final long limit,
                                                             final List<Filter> filters) {
-        throw todo("getConversations");
+        // Match against the stored convo_key JSON: ["location",protocol,"lowerIp","upperIp",app|null]
+        String appPat = applicationPattern;
+        if (".*".equals(appPat)) {
+            appPat = "(\"" + appPat + "\"|null)";
+        } else if (!"null".equals(appPat)) {
+            appPat = "\"" + appPat + "\"";
+        }
+        final String regex = "\\[\"" + locationPattern + "\"," + protocolPattern + ",\"" + lowerIPPattern
+                + "\",\"" + upperIPPattern + "\"," + appPat + "\\]";
+        final String sql = "SELECT DISTINCT convo_key AS e FROM " + table + " WHERE " + where(filters)
+                + " AND convo_key != '' AND match(convo_key, " + quote(regex) + ") ORDER BY e LIMIT " + limit;
+        final List<String> keys = client.queryAll(sql).stream().map(r -> r.getString("e")).collect(Collectors.toList());
+        return CompletableFuture.completedFuture(keys);
     }
 
     @Override
     public CompletableFuture<List<TrafficSummary<Conversation>>> getTopNConversationSummaries(
             final int n, final boolean includeOther, final List<Filter> filters) {
-        throw todo("getTopNConversationSummaries");
+        final String w = where(filters);
+        final String sql = convoSummarySelect(w) + " GROUP BY e ORDER BY (bin + bout) DESC, e LIMIT " + n;
+        final List<TrafficSummary<Conversation>> summaries = convoSummariesFrom(client.queryAll(sql));
+        if (includeOther) {
+            appendOtherConvo(summaries, w);
+        }
+        return CompletableFuture.completedFuture(summaries);
     }
 
     @Override
     public CompletableFuture<List<TrafficSummary<Conversation>>> getConversationSummaries(
             final Set<String> conversations, final boolean includeOther, final List<Filter> filters) {
-        throw todo("getConversationSummaries");
+        if (conversations.isEmpty()) {
+            return CompletableFuture.completedFuture(new ArrayList<>());
+        }
+        final String w = where(filters);
+        final String sql = convoSummarySelect(w) + " WHERE e IN (" + quoteAll(conversations) + ") GROUP BY e ORDER BY e";
+        final List<TrafficSummary<Conversation>> summaries = convoSummariesFrom(client.queryAll(sql));
+        if (includeOther) {
+            appendOtherConvo(summaries, w);
+        }
+        return CompletableFuture.completedFuture(summaries);
     }
 
     @Override
     public CompletableFuture<Table<Directional<Conversation>, Long, Double>> getConversationSeries(
             final Set<String> conversations, final long step, final boolean includeOther, final List<Filter> filters) {
-        throw todo("getConversationSeries");
+        return CompletableFuture.completedFuture(convoSeries(conversations, step, includeOther, filters));
     }
 
     @Override
     public CompletableFuture<Table<Directional<Conversation>, Long, Double>> getTopNConversationSeries(
             final int n, final long step, final boolean includeOther, final List<Filter> filters) {
-        throw todo("getTopNConversationSeries");
+        return CompletableFuture.completedFuture(convoSeries(topNConversations(n, where(filters)), step, includeOther, filters));
+    }
+
+    // --- conversation helpers ---------------------------------------------
+
+    /** Projects each flow to its conversation key plus the lower/upper endpoint hostname. */
+    private String convoProjection(final String whereClause) {
+        return "SELECT convo_key AS e,"
+                + " if(src_addr <= dst_addr, src_hostname, dst_hostname) AS lo_hn,"
+                + " if(src_addr <= dst_addr, dst_hostname, src_hostname) AS up_hn,"
+                + " direction, bytes"
+                + " FROM " + table + " WHERE " + whereClause + " AND convo_key != ''";
+    }
+
+    private String convoSummarySelect(final String whereClause) {
+        return "SELECT e, anyIf(lo_hn, lo_hn != '') AS lower_hn, anyIf(up_hn, up_hn != '') AS upper_hn,"
+                + " sumIf(bytes, direction = 'ingress') AS bin, sumIf(bytes, direction = 'egress') AS bout"
+                + " FROM (" + convoProjection(whereClause) + ")";
+    }
+
+    private static List<TrafficSummary<Conversation>> convoSummariesFrom(final List<GenericRecord> rows) {
+        final List<TrafficSummary<Conversation>> out = new ArrayList<>(rows.size());
+        for (final GenericRecord r : rows) {
+            final Conversation c = conversation(r.getString("e"), r.getString("lower_hn"), r.getString("upper_hn"));
+            if (c != null) {
+                out.add(TrafficSummary.from(c).withBytes(r.getLong("bin"), r.getLong("bout")).build());
+            }
+        }
+        return out;
+    }
+
+    private void appendOtherConvo(final List<TrafficSummary<Conversation>> summaries, final String whereClause) {
+        final List<GenericRecord> grand = client.queryAll(
+                "SELECT sumIf(bytes, direction = 'ingress') AS bin, sumIf(bytes, direction = 'egress') AS bout FROM "
+                        + table + " WHERE " + whereClause + " AND convo_key != ''");
+        final long grandIn = grand.isEmpty() ? 0L : grand.get(0).getLong("bin");
+        final long grandOut = grand.isEmpty() ? 0L : grand.get(0).getLong("bout");
+        final long otherIn = grandIn - summaries.stream().mapToLong(TrafficSummary::getBytesIn).sum();
+        final long otherOut = grandOut - summaries.stream().mapToLong(TrafficSummary::getBytesOut).sum();
+        if (otherIn > 0 || otherOut > 0) {
+            summaries.add(TrafficSummary.from(Conversation.forOther().build()).withBytes(otherIn, otherOut).build());
+        }
+    }
+
+    private Set<String> topNConversations(final int n, final String whereClause) {
+        final String sql = "SELECT convo_key AS e FROM " + table + " WHERE " + whereClause
+                + " AND convo_key != '' GROUP BY convo_key ORDER BY sum(bytes) DESC, e LIMIT " + n;
+        return client.queryAll(sql).stream().map(r -> r.getString("e"))
+                .collect(Collectors.toCollection(LinkedHashSet::new));
+    }
+
+    private Table<Directional<Conversation>, Long, Double> convoSeries(final Set<String> conversations, final long step,
+                                                                       final boolean includeOther, final List<Filter> filters) {
+        final Table<Directional<Conversation>, Long, Double> table = HashBasedTable.create();
+        if (conversations.isEmpty()) {
+            return table;
+        }
+        final long[] range = timeRange(filters);
+        final String w = where(filters);
+        final Map<String, String[]> hostnames = resolveConvoHostnames(conversations, w);
+        final Map<Long, double[]> selectedByBucket = includeOther ? new HashMap<>() : null;
+        final String filter = "convo_key IN (" + quoteAll(conversations) + ")";
+        for (final GenericRecord r : client.queryAll(seriesSql(this.table, "convo_key", filter, w, range[0], range[1], step))) {
+            final String key = r.getString("e");
+            final String[] hn = hostnames.get(key);
+            final Conversation c = conversation(key, hn != null ? hn[0] : null, hn != null ? hn[1] : null);
+            if (c == null) {
+                continue;
+            }
+            final boolean ingress = "ingress".equals(r.getString("d"));
+            final long bucket = r.getLong("b");
+            final double bytes = r.getDouble("bytes");
+            table.put(new Directional<>(c, ingress), bucket, bytes);
+            if (includeOther) {
+                selectedByBucket.computeIfAbsent(bucket, k -> new double[2])[ingress ? 0 : 1] += bytes;
+            }
+        }
+        if (includeOther) {
+            for (final GenericRecord r : client.queryAll(
+                    seriesSql(this.table, null, null, w + " AND convo_key != ''", range[0], range[1], step))) {
+                final boolean ingress = "ingress".equals(r.getString("d"));
+                final long bucket = r.getLong("b");
+                final double other = r.getDouble("bytes")
+                        - selectedByBucket.getOrDefault(bucket, new double[2])[ingress ? 0 : 1];
+                if (Math.abs(other) > 1e-9) {
+                    table.put(new Directional<>(Conversation.forOther().build(), ingress), bucket, other);
+                }
+            }
+        }
+        return table;
+    }
+
+    private Map<String, String[]> resolveConvoHostnames(final Set<String> conversations, final String whereClause) {
+        final Map<String, String[]> map = new HashMap<>();
+        final String sql = "SELECT e, anyIf(lo_hn, lo_hn != '') AS lower_hn, anyIf(up_hn, up_hn != '') AS upper_hn FROM ("
+                + convoProjection(whereClause) + ") WHERE e IN (" + quoteAll(conversations) + ") GROUP BY e";
+        for (final GenericRecord r : client.queryAll(sql)) {
+            map.put(r.getString("e"), new String[]{r.getString("lower_hn"), r.getString("upper_hn")});
+        }
+        return map;
+    }
+
+    /** Build a {@link Conversation} from its stored key JSON, attaching lower/upper hostnames. */
+    private static Conversation conversation(final String convoKey, final String lowerHn, final String upperHn) {
+        final ConversationKey key;
+        try {
+            key = ConversationKeyUtils.fromJsonString(convoKey);
+        } catch (final RuntimeException e) {
+            return null; // malformed key -> skip rather than fail the whole result
+        }
+        final Conversation.Builder b = Conversation.from(key);
+        if (lowerHn != null && !lowerHn.isEmpty()) {
+            b.withLowerHostname(lowerHn);
+        }
+        if (upperHn != null && !upperHn.isEmpty()) {
+            b.withUpperHostname(upperHn);
+        }
+        return b.build();
     }
 
     @Override

--- a/features/flows/clickhouse/src/main/java/org/opennms/netmgt/flows/clickhouse/ClickhouseSchema.java
+++ b/features/flows/clickhouse/src/main/java/org/opennms/netmgt/flows/clickhouse/ClickhouseSchema.java
@@ -33,7 +33,8 @@ public final class ClickhouseSchema {
     /** DDL resources, applied in order; index+1 is the migration version. */
     static final List<String> DDL_RESOURCES = List.of(
             "/ddl/01_flows.sql",
-            "/ddl/02_rollups.sql");
+            "/ddl/02_rollups.sql",
+            "/ddl/03_hostnames.sql");
 
     /** Placeholder in the DDL for the retention window; substituted from {@code ttlDays}. */
     private static final String TTL_PLACEHOLDER = "__TTL_DAYS__";

--- a/features/flows/clickhouse/src/main/java/org/opennms/netmgt/flows/clickhouse/FlowColumns.java
+++ b/features/flows/clickhouse/src/main/java/org/opennms/netmgt/flows/clickhouse/FlowColumns.java
@@ -45,6 +45,9 @@ public final class FlowColumns {
     public static final String SRC_LOCALITY = "src_locality";
     public static final String DST_LOCALITY = "dst_locality";
     public static final String FLOW_LOCALITY = "flow_locality";
+    public static final String SRC_HOSTNAME = "src_hostname";
+    public static final String DST_HOSTNAME = "dst_hostname";
+    public static final String CONVO_KEY = "convo_key";
 
     /** Every column of the {@code flows} table, in DDL order. */
     public static final List<String> ALL = List.of(
@@ -54,7 +57,8 @@ public final class FlowColumns {
             DIRECTION, EXPORTER_NODE, INPUT_SNMP, OUTPUT_SNMP,
             BYTES, PACKETS, FIRST_SWITCHED, LAST_SWITCHED,
             DSCP, ECN, TOS, VLAN, TCP_FLAGS,
-            SRC_LOCALITY, DST_LOCALITY, FLOW_LOCALITY);
+            SRC_LOCALITY, DST_LOCALITY, FLOW_LOCALITY,
+            SRC_HOSTNAME, DST_HOSTNAME, CONVO_KEY);
 
     private FlowColumns() {
     }

--- a/features/flows/clickhouse/src/main/java/org/opennms/netmgt/flows/clickhouse/FlowRowMapper.java
+++ b/features/flows/clickhouse/src/main/java/org/opennms/netmgt/flows/clickhouse/FlowRowMapper.java
@@ -73,6 +73,9 @@ public final class FlowRowMapper {
         n.put(FlowColumns.SRC_LOCALITY, enumName(flow.getSrcLocality()));
         n.put(FlowColumns.DST_LOCALITY, enumName(flow.getDstLocality()));
         n.put(FlowColumns.FLOW_LOCALITY, enumName(flow.getFlowLocality()));
+        n.put(FlowColumns.SRC_HOSTNAME, flow.getSrcAddrHostname().orElse(""));
+        n.put(FlowColumns.DST_HOSTNAME, flow.getDstAddrHostname().orElse(""));
+        n.put(FlowColumns.CONVO_KEY, nz(flow.getConvoKey()));
 
         return n.toString();
     }

--- a/features/flows/clickhouse/src/main/resources/ddl/01_flows.sql
+++ b/features/flows/clickhouse/src/main/resources/ddl/01_flows.sql
@@ -38,7 +38,13 @@ CREATE TABLE IF NOT EXISTS flows
     tcp_flags      UInt16,
     src_locality   Enum8('unknown' = 0, 'public' = 1, 'private' = 2),
     dst_locality   Enum8('unknown' = 0, 'public' = 1, 'private' = 2),
-    flow_locality  Enum8('unknown' = 0, 'public' = 1, 'private' = 2)
+    flow_locality  Enum8('unknown' = 0, 'public' = 1, 'private' = 2),
+    -- Hostnames and the canonical conversation key are denormalised onto each row at
+    -- enrichment time (D-ENRICH); the query service reads them back rather than resolving
+    -- via DAOs. src_hostname/dst_hostname pair with src_addr/dst_addr.
+    src_hostname   String,
+    dst_hostname   String,
+    convo_key      String
 )
 ENGINE = MergeTree
 PARTITION BY toYYYYMMDD(timestamp)

--- a/features/flows/clickhouse/src/main/resources/ddl/03_hostnames.sql
+++ b/features/flows/clickhouse/src/main/resources/ddl/03_hostnames.sql
@@ -1,0 +1,13 @@
+-- SPDX-License-Identifier: AGPL-3.0-or-later
+--
+-- Copyright 2026 The OpenNMS Group, Inc.
+--
+-- Created by Ronny Trommer <ronny@opennms.com>
+--
+-- Migration v3: denormalised hostname + conversation-key columns on the raw flows table
+-- (D-ENRICH). Fresh installs already get these from 01_flows.sql; this migration adds them
+-- to deployments created before the columns existed. IF NOT EXISTS keeps it idempotent.
+
+ALTER TABLE flows ADD COLUMN IF NOT EXISTS src_hostname String;
+ALTER TABLE flows ADD COLUMN IF NOT EXISTS dst_hostname String;
+ALTER TABLE flows ADD COLUMN IF NOT EXISTS convo_key String;


### PR DESCRIPTION
## Summary

Completes the `ClickhouseFlowQueryService` read path begun in #166. With this, all **19** `FlowQueryService` methods are implemented against ClickHouse across every dimension — application, **field (DSCP)**, **host**, **conversation** — with enumeration, top-N and specific summaries/series, `includeOther`, and proportional byte distribution.

### What's added
- **Field (DSCP):** values / summaries / series. `seriesSql` generalized to any entity column.
- **Host:** `getHosts` (regex via `match()`), top-N/specific summaries & series. A flow counts toward **both** endpoints via a src/dst `UNION`; `seriesSql` further generalized with a `fromExpr` so app/field/host/conversation share one proportional engine.
- **Conversation:** enumeration via `match()` over the stored `convo_key` JSON; summaries & series grouped by `convo_key` (both directions collapse to one canonical key); lower/upper hostnames mapped from stored hostnames by IP ordering; entity rebuilt via `ConversationKeyUtils`.
- **Enrichment (D-ENRICH), schema migration v3:** denormalise `src_hostname` / `dst_hostname` / `convo_key` onto each flow row and read them back — matching the ES stored-field model, so **no `NodeDao`/`ipInterfaceDao`** is wired into the query bean. `FlowColumns` + mapper extended in sync (drift guard test stays green).

## Verification
- 10 unit tests pass (filters, mapper drift-guard, quote escaping).
- Every query verified against **ClickHouse 24.8**: count, enumerations, top-N/specific summaries + `includeOther`, and proportional series (250/500/250) for application, field, host and conversation; host double-endpoint counting; conversation canonical-key + lower/upper hostname mapping; migration v3 idempotency.

## Not in this PR (tracked follow-ups)
- **3.7 rollup routing:** long-range queries still hit the raw table; raw-vs-`*_1m` selection is TODO.
- **3.8:** the service is **not yet registered** as the OSGi `FlowQueryService` (the Elasticsearch one still exists until the phase-6 ES removal), so this code is additive/dormant.
- **Phase-4 oracle reconciliation:** exact `Unknown`/`Other` labels and IPv4 rendering (currently v4-mapped `::ffff:…`) to match `FlowQueryIT`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)