### PR TITLE
feat(flows): ClickHouse rollup routing for summaries (3.7)

### DIFF
--- a/features/flows/clickhouse/src/main/java/org/opennms/netmgt/flows/clickhouse/ClickhouseFlowQueryService.java
+++ b/features/flows/clickhouse/src/main/java/org/opennms/netmgt/flows/clickhouse/ClickhouseFlowQueryService.java
@@ -56,6 +56,9 @@ public class ClickhouseFlowQueryService implements FlowQueryService {
     // queries use the exact raw table; the rollup path is opt-in. Rollups back SUMMARIES only — their
     // point-in-time bucketing does not reproduce the proportional series — and only when the filters
     // reference columns the rollup carries (time range + exporter node).
+    // NOTE: currently wired for the APPLICATION summaries only; host/conversation/field summaries and
+    // all series stay on the raw path regardless of these flags (host/conversation rollup summaries
+    // are a follow-on). The flags/threshold therefore affect application summaries today.
     private String appRollupTable = "flows_by_app_1m";
     private boolean alwaysUseRawForQueries = true;
     private boolean alwaysUseAggForQueries = false;
@@ -107,9 +110,9 @@ public class ClickhouseFlowQueryService implements FlowQueryService {
     public CompletableFuture<List<TrafficSummary<String>>> getTopNApplicationSummaries(final int n,
                                                                                        final boolean includeOther,
                                                                                        final List<Filter> filters) {
-        final boolean rollup = useAppRollup(filters);
-        final String from = rollup ? appRollupTable : table;
-        final String w = rollup ? rollupWhere(filters) : where(filters);
+        final String[] target = appTarget(filters);
+        final String from = target[0];
+        final String w = target[1];
         final String sql = appSummarySelect(from, w) + " GROUP BY application ORDER BY (bin + bout) DESC, e LIMIT " + n;
         final List<TrafficSummary<String>> summaries = summariesFrom(client.queryAll(sql));
         if (includeOther) {
@@ -125,9 +128,9 @@ public class ClickhouseFlowQueryService implements FlowQueryService {
         if (applications.isEmpty()) {
             return CompletableFuture.completedFuture(new ArrayList<>());
         }
-        final boolean rollup = useAppRollup(filters);
-        final String from = rollup ? appRollupTable : table;
-        final String w = rollup ? rollupWhere(filters) : where(filters);
+        final String[] target = appTarget(filters);
+        final String from = target[0];
+        final String w = target[1];
         final String sql = appSummarySelect(from, w) + " AND application IN (" + quoteAll(applications) + ")"
                 + " GROUP BY application ORDER BY e";
         final List<TrafficSummary<String>> summaries = summariesFrom(client.queryAll(sql));
@@ -135,6 +138,13 @@ public class ClickhouseFlowQueryService implements FlowQueryService {
             appendOther(summaries, from, w);
         }
         return CompletableFuture.completedFuture(summaries);
+    }
+
+    /** Returns {fromTable, whereClause} for an application summary, routed to the rollup when enabled. */
+    private String[] appTarget(final List<Filter> filters) {
+        return useAppRollup(filters)
+                ? new String[]{appRollupTable, rollupWhere(filters)}
+                : new String[]{table, where(filters)};
     }
 
     private static String appSummarySelect(final String from, final String whereClause) {
@@ -156,9 +166,11 @@ public class ClickhouseFlowQueryService implements FlowQueryService {
         if (alwaysUseAggForQueries) {
             return true;
         }
-        for (final Filter f : filters) {
-            if (f instanceof TimeRangeFilter t && t.getDurationMs() > aggregateThresholdMs) {
-                return true;
+        if (filters != null) {
+            for (final Filter f : filters) {
+                if (f instanceof TimeRangeFilter t && t.getDurationMs() > aggregateThresholdMs) {
+                    return true;
+                }
             }
         }
         return false;
@@ -185,8 +197,11 @@ public class ClickhouseFlowQueryService implements FlowQueryService {
         final List<String> parts = new ArrayList<>();
         for (final Filter f : filters) {
             if (f instanceof TimeRangeFilter t) {
-                parts.add("(bucket >= fromUnixTimestamp(" + (t.getStart() / 1000)
-                        + ") AND bucket < fromUnixTimestamp(" + (t.getEnd() / 1000) + "))");
+                // Round the lower bound down to the minute bucket that CONTAINS the range start, so
+                // the first (partial) bucket is included rather than dropped; milli precision matches
+                // the raw path. Point-in-time rollups are inherently minute-granular at the edges.
+                parts.add("(bucket >= toStartOfMinute(fromUnixTimestamp64Milli(" + t.getStart()
+                        + ")) AND bucket < fromUnixTimestamp64Milli(" + t.getEnd() + "))");
             } else if (f instanceof ExporterNodeFilter en) {
                 final Integer nodeId = en.getCriteria().getNodeId();
                 if (nodeId == null) {

--- a/features/flows/clickhouse/src/main/java/org/opennms/netmgt/flows/clickhouse/ClickhouseFlowQueryService.java
+++ b/features/flows/clickhouse/src/main/java/org/opennms/netmgt/flows/clickhouse/ClickhouseFlowQueryService.java
@@ -24,6 +24,7 @@ import org.opennms.netmgt.flows.api.FlowQueryService;
 import org.opennms.netmgt.flows.api.Host;
 import org.opennms.netmgt.flows.api.LimitedCardinalityField;
 import org.opennms.netmgt.flows.api.TrafficSummary;
+import org.opennms.netmgt.flows.filter.api.ExporterNodeFilter;
 import org.opennms.netmgt.flows.filter.api.Filter;
 import org.opennms.netmgt.flows.filter.api.TimeRangeFilter;
 import org.opennms.netmgt.flows.processing.ConversationKeyUtils;
@@ -51,9 +52,34 @@ public class ClickhouseFlowQueryService implements FlowQueryService {
     private final Client client;
     private final String table;
 
+    // Rollup routing (D-QUERY). Defaults mirror the ES SmartQueryService default (alwaysUseRaw=true):
+    // queries use the exact raw table; the rollup path is opt-in. Rollups back SUMMARIES only — their
+    // point-in-time bucketing does not reproduce the proportional series — and only when the filters
+    // reference columns the rollup carries (time range + exporter node).
+    private String appRollupTable = "flows_by_app_1m";
+    private boolean alwaysUseRawForQueries = true;
+    private boolean alwaysUseAggForQueries = false;
+    private long aggregateThresholdMs = 120_000L;
+
     public ClickhouseFlowQueryService(final Client client, final String table) {
         this.client = Objects.requireNonNull(client);
         this.table = Objects.requireNonNull(table);
+    }
+
+    public void setAppRollupTable(final String appRollupTable) {
+        this.appRollupTable = appRollupTable;
+    }
+
+    public void setAlwaysUseRawForQueries(final boolean alwaysUseRawForQueries) {
+        this.alwaysUseRawForQueries = alwaysUseRawForQueries;
+    }
+
+    public void setAlwaysUseAggForQueries(final boolean alwaysUseAggForQueries) {
+        this.alwaysUseAggForQueries = alwaysUseAggForQueries;
+    }
+
+    public void setAggregateThresholdMs(final long aggregateThresholdMs) {
+        this.aggregateThresholdMs = aggregateThresholdMs;
     }
 
     @Override
@@ -81,15 +107,13 @@ public class ClickhouseFlowQueryService implements FlowQueryService {
     public CompletableFuture<List<TrafficSummary<String>>> getTopNApplicationSummaries(final int n,
                                                                                        final boolean includeOther,
                                                                                        final List<Filter> filters) {
-        final String w = where(filters);
-        final String sql = "SELECT application AS e,"
-                + " sumIf(bytes, direction = 'ingress') AS bin,"
-                + " sumIf(bytes, direction = 'egress') AS bout"
-                + " FROM " + table + " WHERE " + w
-                + " GROUP BY application ORDER BY (bin + bout) DESC, e LIMIT " + n;
+        final boolean rollup = useAppRollup(filters);
+        final String from = rollup ? appRollupTable : table;
+        final String w = rollup ? rollupWhere(filters) : where(filters);
+        final String sql = appSummarySelect(from, w) + " GROUP BY application ORDER BY (bin + bout) DESC, e LIMIT " + n;
         final List<TrafficSummary<String>> summaries = summariesFrom(client.queryAll(sql));
         if (includeOther) {
-            appendOther(summaries, w);
+            appendOther(summaries, from, w);
         }
         return CompletableFuture.completedFuture(summaries);
     }
@@ -101,17 +125,78 @@ public class ClickhouseFlowQueryService implements FlowQueryService {
         if (applications.isEmpty()) {
             return CompletableFuture.completedFuture(new ArrayList<>());
         }
-        final String w = where(filters);
-        final String sql = "SELECT application AS e,"
-                + " sumIf(bytes, direction = 'ingress') AS bin,"
-                + " sumIf(bytes, direction = 'egress') AS bout"
-                + " FROM " + table + " WHERE " + w + " AND application IN (" + quoteAll(applications) + ")"
+        final boolean rollup = useAppRollup(filters);
+        final String from = rollup ? appRollupTable : table;
+        final String w = rollup ? rollupWhere(filters) : where(filters);
+        final String sql = appSummarySelect(from, w) + " AND application IN (" + quoteAll(applications) + ")"
                 + " GROUP BY application ORDER BY e";
         final List<TrafficSummary<String>> summaries = summariesFrom(client.queryAll(sql));
         if (includeOther) {
-            appendOther(summaries, w);
+            appendOther(summaries, from, w);
         }
         return CompletableFuture.completedFuture(summaries);
+    }
+
+    private static String appSummarySelect(final String from, final String whereClause) {
+        return "SELECT application AS e,"
+                + " sumIf(bytes, direction = 'ingress') AS bin,"
+                + " sumIf(bytes, direction = 'egress') AS bout"
+                + " FROM " + from + " WHERE " + whereClause;
+    }
+
+    /**
+     * Choose the per-minute application rollup over the raw table when routing is enabled and the
+     * filters only reference columns the rollup carries (time range + exporter node). Summaries only
+     * (D-QUERY); series always use the raw proportional path.
+     */
+    private boolean useAppRollup(final List<Filter> filters) {
+        if (alwaysUseRawForQueries || !rollupCompatible(filters)) {
+            return false;
+        }
+        if (alwaysUseAggForQueries) {
+            return true;
+        }
+        for (final Filter f : filters) {
+            if (f instanceof TimeRangeFilter t && t.getDurationMs() > aggregateThresholdMs) {
+                return true;
+            }
+        }
+        return false;
+    }
+
+    /** The rollup tables carry only time (bucket) + exporter_node, so any other filter forces raw. */
+    static boolean rollupCompatible(final List<Filter> filters) {
+        if (filters == null) {
+            return true;
+        }
+        for (final Filter f : filters) {
+            if (!(f instanceof TimeRangeFilter) && !(f instanceof ExporterNodeFilter)) {
+                return false;
+            }
+        }
+        return true;
+    }
+
+    /** WHERE fragment against the rollup columns: bucket range + exporter_node. */
+    static String rollupWhere(final List<Filter> filters) {
+        if (filters == null || filters.isEmpty()) {
+            return "1 = 1";
+        }
+        final List<String> parts = new ArrayList<>();
+        for (final Filter f : filters) {
+            if (f instanceof TimeRangeFilter t) {
+                parts.add("(bucket >= fromUnixTimestamp(" + (t.getStart() / 1000)
+                        + ") AND bucket < fromUnixTimestamp(" + (t.getEnd() / 1000) + "))");
+            } else if (f instanceof ExporterNodeFilter en) {
+                final Integer nodeId = en.getCriteria().getNodeId();
+                if (nodeId == null) {
+                    throw new UnsupportedOperationException(
+                            "ExporterNodeFilter with foreignSource:foreignId is not supported on the rollup path.");
+                }
+                parts.add("exporter_node = " + nodeId);
+            }
+        }
+        return parts.isEmpty() ? "1 = 1" : String.join(" AND ", parts);
     }
 
     // --- helpers ----------------------------------------------------------
@@ -136,10 +221,10 @@ public class ClickhouseFlowQueryService implements FlowQueryService {
     }
 
     /** Add the "Other" bucket = grand total (matching the filters) minus the summaries already collected. */
-    private void appendOther(final List<TrafficSummary<String>> summaries, final String whereClause) {
+    private void appendOther(final List<TrafficSummary<String>> summaries, final String from, final String whereClause) {
         final List<GenericRecord> grand = client.queryAll(
                 "SELECT sumIf(bytes, direction = 'ingress') AS bin, sumIf(bytes, direction = 'egress') AS bout"
-                        + " FROM " + table + " WHERE " + whereClause);
+                        + " FROM " + from + " WHERE " + whereClause);
         final long grandIn = grand.isEmpty() ? 0L : grand.get(0).getLong("bin");
         final long grandOut = grand.isEmpty() ? 0L : grand.get(0).getLong("bout");
         final long topIn = summaries.stream().mapToLong(TrafficSummary::getBytesIn).sum();

--- a/features/flows/clickhouse/src/test/java/org/opennms/netmgt/flows/clickhouse/ClickhouseFlowQueryServiceTest.java
+++ b/features/flows/clickhouse/src/test/java/org/opennms/netmgt/flows/clickhouse/ClickhouseFlowQueryServiceTest.java
@@ -8,8 +8,17 @@
 package org.opennms.netmgt.flows.clickhouse;
 
 import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertTrue;
+
+import java.util.List;
 
 import org.junit.Test;
+import org.opennms.netmgt.flows.filter.api.DscpFilter;
+import org.opennms.netmgt.flows.filter.api.ExporterNodeFilter;
+import org.opennms.netmgt.flows.filter.api.NodeCriteria;
+import org.opennms.netmgt.flows.filter.api.SnmpInterfaceIdFilter;
+import org.opennms.netmgt.flows.filter.api.TimeRangeFilter;
 
 public class ClickhouseFlowQueryServiceTest {
 
@@ -21,5 +30,25 @@ public class ClickhouseFlowQueryServiceTest {
         // trailing backslash must not escape the closing quote
         assertEquals("'foo\\\\'", ClickhouseFlowQueryService.quote("foo\\"));
         assertEquals("'a\\\\''b'", ClickhouseFlowQueryService.quote("a\\'b"));
+    }
+
+    /** Only time-range + exporter-node filters exist on the rollup tables; anything else forces raw. */
+    @Test
+    public void rollupCompatibility() {
+        assertTrue(ClickhouseFlowQueryService.rollupCompatible(List.of()));
+        assertTrue(ClickhouseFlowQueryService.rollupCompatible(
+                List.of(new TimeRangeFilter(0, 10), new ExporterNodeFilter(new NodeCriteria(1)))));
+        assertFalse(ClickhouseFlowQueryService.rollupCompatible(List.of(new DscpFilter(List.of(46)))));
+        assertFalse(ClickhouseFlowQueryService.rollupCompatible(List.of(new SnmpInterfaceIdFilter(3))));
+    }
+
+    /** Rollup WHERE targets the bucket/exporter_node columns, not the raw timestamp/snmp columns. */
+    @Test
+    public void rollupWhereUsesBucketColumns() {
+        assertEquals("(bucket >= fromUnixTimestamp(1) AND bucket < fromUnixTimestamp(2))",
+                ClickhouseFlowQueryService.rollupWhere(List.of(new TimeRangeFilter(1000, 2000))));
+        assertEquals("exporter_node = 7",
+                ClickhouseFlowQueryService.rollupWhere(List.of(new ExporterNodeFilter(new NodeCriteria(7)))));
+        assertEquals("1 = 1", ClickhouseFlowQueryService.rollupWhere(List.of()));
     }
 }

--- a/features/flows/clickhouse/src/test/java/org/opennms/netmgt/flows/clickhouse/ClickhouseFlowQueryServiceTest.java
+++ b/features/flows/clickhouse/src/test/java/org/opennms/netmgt/flows/clickhouse/ClickhouseFlowQueryServiceTest.java
@@ -45,7 +45,7 @@ public class ClickhouseFlowQueryServiceTest {
     /** Rollup WHERE targets the bucket/exporter_node columns, not the raw timestamp/snmp columns. */
     @Test
     public void rollupWhereUsesBucketColumns() {
-        assertEquals("(bucket >= fromUnixTimestamp(1) AND bucket < fromUnixTimestamp(2))",
+        assertEquals("(bucket >= toStartOfMinute(fromUnixTimestamp64Milli(1000)) AND bucket < fromUnixTimestamp64Milli(2000))",
                 ClickhouseFlowQueryService.rollupWhere(List.of(new TimeRangeFilter(1000, 2000))));
         assertEquals("exporter_node = 7",
                 ClickhouseFlowQueryService.rollupWhere(List.of(new ExporterNodeFilter(new NodeCriteria(7)))));


### PR DESCRIPTION
## Summary

Adds config-driven raw-vs-rollup table selection to `ClickhouseFlowQueryService` (design 3.7 / D-QUERY), mirroring the ES `SmartQueryService` defaults.

- **Config:** `alwaysUseRawForQueries` (default **true** = exact raw path, ES parity), `alwaysUseAggForQueries`, `aggregateThresholdMs`; setters for blueprint wiring in 3.8.
- **Selector:** routes **application summaries** to the `flows_by_app_1m` rollup when routing is enabled and the filters are rollup-compatible (only time-range + exporter-node — the columns the rollup carries; DSCP/SNMP filters force raw).
- **Series stay raw:** the rollup MVs bucket *point-in-time*, not proportionally, so they back **summaries only**. Long-range series from rollups would need proportional (Nephron-equivalent) rollups — a documented follow-on.

## Verification
- 12 unit tests (added `rollupCompatible` / `rollupWhere` coverage).
- Against ClickHouse 24.8: rollup app-summary returns the **same totals as raw**; corrected bucket bound includes the range-start's containing minute bucket.

## Review fixes included
Bucket-bound undercount (non-aligned start dropped the first bucket), null-filter NPE, selection-preamble dedup, config-scope doc clarification.

## Follow-ups
Host/conversation rollup summaries; proportional rollups for long-range series; 3.8 service registration; phase-4 Testcontainer ITs (which will exercise the rollup path against a DB).

🤖 Generated with [Claude Code](https://claude.com/claude-code)