### PR TITLE
test(flows): ClickHouse Testcontainer IT + client-v2 connection fix

### DIFF
--- a/features/flows/clickhouse/pom.xml
+++ b/features/flows/clickhouse/pom.xml
@@ -135,5 +135,18 @@
       <artifactId>mockito-core</artifactId>
       <scope>test</scope>
     </dependency>
+    <dependency>
+      <groupId>org.testcontainers</groupId>
+      <artifactId>clickhouse</artifactId>
+      <version>${testcontainers.version}</version>
+      <scope>test</scope>
+      <exclusions>
+        <!-- clickhouse-jdbc drags in the enforcer-banned org.lz4:lz4-java. -->
+        <exclusion>
+          <groupId>org.lz4</groupId>
+          <artifactId>lz4-java</artifactId>
+        </exclusion>
+      </exclusions>
+    </dependency>
   </dependencies>
 </project>

--- a/features/flows/clickhouse/src/main/java/org/opennms/netmgt/flows/clickhouse/ClickhouseClientFactory.java
+++ b/features/flows/clickhouse/src/main/java/org/opennms/netmgt/flows/clickhouse/ClickhouseClientFactory.java
@@ -39,6 +39,10 @@ public class ClickhouseClientFactory {
                 .setPassword(password)
                 .setDefaultDatabase(database)
                 .setClientName("opennms-flows-clickhouse")
+                // client-v2 0.8.6's pooled connection manager times out leasing a connection even to
+                // a reachable server (ConnectionRequestTimeout on the first request); disable pooling
+                // so each request opens a fresh (working) connection.
+                .enableConnectionPool(false)
                 .build();
     }
 }

--- a/features/flows/clickhouse/src/main/java/org/opennms/netmgt/flows/clickhouse/ClickhouseFlowRepository.java
+++ b/features/flows/clickhouse/src/main/java/org/opennms/netmgt/flows/clickhouse/ClickhouseFlowRepository.java
@@ -15,7 +15,6 @@ import java.util.List;
 import java.util.Objects;
 import java.util.Timer;
 import java.util.TimerTask;
-import java.util.concurrent.ExecutionException;
 import java.util.concurrent.locks.ReentrantLock;
 
 import org.opennms.integration.api.v1.flows.Flow;
@@ -25,6 +24,7 @@ import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
 import com.clickhouse.client.api.Client;
+import com.clickhouse.client.api.insert.InsertResponse;
 import com.clickhouse.data.ClickHouseFormat;
 import com.codahale.metrics.Meter;
 import com.codahale.metrics.MetricRegistry;
@@ -111,17 +111,18 @@ public class ClickhouseFlowRepository implements FlowRepository {
         }
         final String payload = String.join("\n", buffer);
         final int count = buffer.size();
-        try (final Context ctx = logPersistingTimer.time()) {
-            client.insert(table,
-                          new ByteArrayInputStream(payload.getBytes(StandardCharsets.UTF_8)),
-                          ClickHouseFormat.JSONEachRow).get();
+        // The InsertResponse must be closed to release the connection for the next flush.
+        try (final Context ctx = logPersistingTimer.time();
+             final InsertResponse response = client.insert(table,
+                     new ByteArrayInputStream(payload.getBytes(StandardCharsets.UTF_8)),
+                     ClickHouseFormat.JSONEachRow).get()) {
             flowsPersistedMeter.mark(count);
             buffer.clear();
             lastPersist = System.currentTimeMillis();
         } catch (final InterruptedException e) {
             Thread.currentThread().interrupt();
             throw new FlowException("Interrupted while persisting flows to ClickHouse.", e);
-        } catch (final ExecutionException e) {
+        } catch (final Exception e) {
             throw new FlowException("Failed to persist " + count + " flows to ClickHouse.", e);
         }
     }

--- a/features/flows/clickhouse/src/main/java/org/opennms/netmgt/flows/clickhouse/ClickhouseSchemaBootstrap.java
+++ b/features/flows/clickhouse/src/main/java/org/opennms/netmgt/flows/clickhouse/ClickhouseSchemaBootstrap.java
@@ -9,7 +9,6 @@ package org.opennms.netmgt.flows.clickhouse;
 
 import java.util.List;
 import java.util.Objects;
-import java.util.concurrent.ExecutionException;
 
 import org.opennms.netmgt.flows.clickhouse.ClickhouseSchema.Migration;
 import org.slf4j.Logger;
@@ -17,6 +16,7 @@ import org.slf4j.LoggerFactory;
 
 import com.clickhouse.client.api.Client;
 import com.clickhouse.client.api.query.GenericRecord;
+import com.clickhouse.client.api.query.QueryResponse;
 
 /**
  * Creates the flow schema on startup and applies any not-yet-applied migrations. Applied versions
@@ -67,12 +67,13 @@ public class ClickhouseSchemaBootstrap {
     }
 
     private void execute(final String statement) {
-        try {
-            client.query(statement).get();
+        // The QueryResponse must be closed to release the connection for the next statement.
+        try (final QueryResponse response = client.query(statement).get()) {
+            // DDL has no result set to read.
         } catch (final InterruptedException e) {
             Thread.currentThread().interrupt();
             throw new IllegalStateException("Interrupted while applying ClickHouse schema DDL.", e);
-        } catch (final ExecutionException e) {
+        } catch (final Exception e) {
             throw new IllegalStateException("Failed to apply ClickHouse schema DDL: " + statement, e);
         }
     }

--- a/features/flows/clickhouse/src/test/java/org/opennms/netmgt/flows/clickhouse/ClickhouseFlowIT.java
+++ b/features/flows/clickhouse/src/test/java/org/opennms/netmgt/flows/clickhouse/ClickhouseFlowIT.java
@@ -18,7 +18,6 @@ import java.util.Optional;
 
 import org.junit.AfterClass;
 import org.junit.BeforeClass;
-import org.junit.Ignore;
 import org.junit.Test;
 import org.opennms.integration.api.v1.flows.Flow;
 import org.opennms.netmgt.flows.api.TrafficSummary;
@@ -35,12 +34,6 @@ import com.codahale.metrics.MetricRegistry;
  * gotcha). This is the seed of the phase-4 oracle harness; the full {@code FlowQueryIT} assertions
  * are ported on top.
  */
-@Ignore("BLOCKED: client-v2 0.8.6 HTTP transport times out acquiring a connection to the "
-        + "Testcontainers ClickHouse (ConnectionRequestTimeout) even though a raw HTTP /ping to the "
-        + "same host:port returns 200. Not a flow-logic issue (all SQL is verified via unit tests + "
-        + "manual ClickHouse runs). TODO: resolve the client-v2 connection config (or bump the client "
-        + "version), then remove @Ignore. Tried: 127.0.0.1 vs localhost, compression off, explicit "
-        + "addEndpoint(Protocol,host,port,secure) — none fixed it.")
 public class ClickhouseFlowIT {
 
     private static final Instant T = Instant.parse("2026-07-10T10:00:00Z");

--- a/features/flows/clickhouse/src/test/java/org/opennms/netmgt/flows/clickhouse/ClickhouseFlowIT.java
+++ b/features/flows/clickhouse/src/test/java/org/opennms/netmgt/flows/clickhouse/ClickhouseFlowIT.java
@@ -1,0 +1,138 @@
+/*
+ * SPDX-License-Identifier: AGPL-3.0-or-later
+ *
+ * Copyright 2026 The OpenNMS Group, Inc.
+ *
+ * Created by Ronny Trommer <ronny@opennms.com>
+ */
+package org.opennms.netmgt.flows.clickhouse;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertTrue;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
+
+import java.time.Instant;
+import java.util.List;
+import java.util.Optional;
+
+import org.junit.AfterClass;
+import org.junit.BeforeClass;
+import org.junit.Ignore;
+import org.junit.Test;
+import org.opennms.integration.api.v1.flows.Flow;
+import org.opennms.netmgt.flows.api.TrafficSummary;
+import org.testcontainers.clickhouse.ClickHouseContainer;
+import org.testcontainers.utility.DockerImageName;
+
+import com.clickhouse.client.api.Client;
+import com.codahale.metrics.MetricRegistry;
+
+/**
+ * End-to-end integration test of the ClickHouse flow stack against a real server: schema bootstrap,
+ * the Path A {@link ClickhouseFlowRepository} write path, and the {@link ClickhouseFlowQueryService}
+ * read path. Runs with {@code ttlDays=0} so fixture timestamps are never TTL-expired (spike-0.2
+ * gotcha). This is the seed of the phase-4 oracle harness; the full {@code FlowQueryIT} assertions
+ * are ported on top.
+ */
+@Ignore("BLOCKED: client-v2 0.8.6 HTTP transport times out acquiring a connection to the "
+        + "Testcontainers ClickHouse (ConnectionRequestTimeout) even though a raw HTTP /ping to the "
+        + "same host:port returns 200. Not a flow-logic issue (all SQL is verified via unit tests + "
+        + "manual ClickHouse runs). TODO: resolve the client-v2 connection config (or bump the client "
+        + "version), then remove @Ignore. Tried: 127.0.0.1 vs localhost, compression off, explicit "
+        + "addEndpoint(Protocol,host,port,secure) — none fixed it.")
+public class ClickhouseFlowIT {
+
+    private static final Instant T = Instant.parse("2026-07-10T10:00:00Z");
+
+    private static ClickHouseContainer clickhouse;
+    private static Client client;
+    private static ClickhouseFlowQueryService query;
+
+    @BeforeClass
+    public static void setUp() throws Exception {
+        clickhouse = new ClickHouseContainer(DockerImageName.parse("clickhouse/clickhouse-server:24.8"));
+        clickhouse.start();
+
+        // Use 127.0.0.1 rather than the "localhost" testcontainers reports: the client's HTTP
+        // transport otherwise tries the IPv6 loopback (::1), where the mapped port isn't bound, and
+        // hangs until the connection-request timeout.
+        final String host = "localhost".equals(clickhouse.getHost()) ? "127.0.0.1" : clickhouse.getHost();
+        final String endpoint = "http://" + host + ":" + clickhouse.getMappedPort(8123);
+        client = new ClickhouseClientFactory(endpoint, clickhouse.getUsername(), clickhouse.getPassword(), "default")
+                .createClient();
+
+        new ClickhouseSchemaBootstrap(client, 0).initialize();
+
+        final ClickhouseFlowRepository repository = new ClickhouseFlowRepository(new MetricRegistry(), client, "flows");
+        repository.setBulkSize(1); // flush each persist() synchronously
+        repository.persist(List.of(
+                flow("http", "10.0.0.1", "10.0.0.2", Flow.Direction.INGRESS, 100L),
+                flow("http", "10.0.0.2", "10.0.0.1", Flow.Direction.EGRESS, 40L),
+                flow("https", "10.0.0.1", "10.0.0.3", Flow.Direction.INGRESS, 200L)));
+
+        query = new ClickhouseFlowQueryService(client, "flows");
+    }
+
+    @AfterClass
+    public static void tearDown() {
+        if (client != null) {
+            client.close();
+        }
+        if (clickhouse != null) {
+            clickhouse.stop();
+        }
+    }
+
+    @Test
+    public void countsPersistedFlows() throws Exception {
+        assertEquals(Long.valueOf(3), query.getFlowCount(List.of()).get());
+    }
+
+    @Test
+    public void enumeratesApplications() throws Exception {
+        assertEquals(List.of("http", "https"), query.getApplications("", 10, List.of()).get());
+    }
+
+    @Test
+    public void topNApplicationSummariesMatchIngestedBytes() throws Exception {
+        final List<TrafficSummary<String>> summaries = query.getTopNApplicationSummaries(10, false, List.of()).get();
+        assertEquals(2, summaries.size());
+        // https has the most total bytes (200) and sorts first.
+        final TrafficSummary<String> https = summaries.get(0);
+        assertEquals("https", https.getEntity());
+        assertEquals(200L, https.getBytesIn());
+        assertEquals(0L, https.getBytesOut());
+        final TrafficSummary<String> http = summaries.get(1);
+        assertEquals("http", http.getEntity());
+        assertEquals(100L, http.getBytesIn());
+        assertEquals(40L, http.getBytesOut());
+    }
+
+    @Test
+    public void includeOtherAddsResidual() throws Exception {
+        final List<TrafficSummary<String>> summaries = query.getTopNApplicationSummaries(1, true, List.of()).get();
+        // top-1 = https(200/0); Other = everything else = http(100/40)
+        assertEquals(2, summaries.size());
+        assertTrue(summaries.stream().anyMatch(s -> "Other".equals(s.getEntity())
+                && s.getBytesIn() == 100L && s.getBytesOut() == 40L));
+    }
+
+    private static Flow flow(final String application, final String src, final String dst,
+                             final Flow.Direction direction, final long bytes) {
+        final Flow f = mock(Flow.class);
+        when(f.getApplication()).thenReturn(application);
+        when(f.getSrcAddr()).thenReturn(src);
+        when(f.getDstAddr()).thenReturn(dst);
+        when(f.getDirection()).thenReturn(direction);
+        when(f.getBytes()).thenReturn(bytes);
+        when(f.getProtocol()).thenReturn(6);
+        when(f.getTimestamp()).thenReturn(T);
+        when(f.getFirstSwitched()).thenReturn(T);
+        when(f.getLastSwitched()).thenReturn(T);
+        when(f.getSrcAddrHostname()).thenReturn(Optional.empty());
+        when(f.getDstAddrHostname()).thenReturn(Optional.empty());
+        when(f.getNextHopHostname()).thenReturn(Optional.empty());
+        return f;
+    }
+}


### PR DESCRIPTION
## Summary

Adds the first DB-backed integration test for the ClickHouse flow module and fixes two client-v2 connection bugs it uncovered — the first time the real client-v2 Java transport was exercised (prior verification was curl / `clickhouse-client`).

### Connection fix (production bug)
The `ClickhouseClientFactory` merged in #166/#167 could **not** actually connect to ClickHouse:
- client-v2 0.8.6's pooled connection manager times out leasing a connection even to a reachable server (`ConnectionRequestTimeout`) → **`enableConnectionPool(false)`** so each request opens a fresh connection.
- `QueryResponse` / `InsertResponse` were never closed → the connection stayed "still allocated" for the next request → **close them via try-with-resources** in `ClickhouseSchemaBootstrap` and `ClickhouseFlowRepository`.

The module is dormant (not yet registered in any feature), so there was no live impact — but it could not have worked at runtime without this.

### Integration test (`ClickhouseFlowIT`)
Testcontainers ClickHouse → schema bootstrap (`ttlDays=0`) → `ClickhouseFlowRepository` write → `ClickhouseFlowQueryService` asserts: flow count, application enumeration, top-N summaries, and the `includeOther` residual. Enforcer-banned `org.lz4:lz4-java` excluded from the `testcontainers:clickhouse` dep.

## Verification
`make`-equivalent `verify` green: **12 unit tests + 4 IT tests pass** against ClickHouse 24.8.

## Follow-up
Port the full `FlowQueryIT` / `AggregatedFlowQueryIT` assertions onto this harness (host/conversation/field dimensions + proportional series), which also forces the phase-4 oracle reconciliation (`Unknown`/`Other` labels, IPv4 dotted-quad display).

🤖 Generated with [Claude Code](https://claude.com/claude-code)