### PR TITLE
test(flows): FlowQueryIT oracle IT + ES-contract reconciliation

### DIFF
--- a/features/flows/clickhouse/src/main/java/org/opennms/netmgt/flows/clickhouse/ClickhouseFlowQueryService.java
+++ b/features/flows/clickhouse/src/main/java/org/opennms/netmgt/flows/clickhouse/ClickhouseFlowQueryService.java
@@ -49,6 +49,9 @@ public class ClickhouseFlowQueryService implements FlowQueryService {
     /** Synthetic entity for the aggregate of everything outside the returned top-N (D-OTHER). */
     static final String OTHER_APPLICATION = "Other";
 
+    /** Label for flows with no classified application (matches the ES contract). */
+    static final String UNKNOWN_APPLICATION = "Unknown";
+
     private final Client client;
     private final String table;
 
@@ -148,7 +151,8 @@ public class ClickhouseFlowQueryService implements FlowQueryService {
     }
 
     private static String appSummarySelect(final String from, final String whereClause) {
-        return "SELECT application AS e,"
+        // Unclassified flows (empty application) surface as the "Unknown" entity, matching ES.
+        return "SELECT if(application = '', '" + UNKNOWN_APPLICATION + "', application) AS e,"
                 + " sumIf(bytes, direction = 'ingress') AS bin,"
                 + " sumIf(bytes, direction = 'egress') AS bout"
                 + " FROM " + from + " WHERE " + whereClause;
@@ -246,9 +250,8 @@ public class ClickhouseFlowQueryService implements FlowQueryService {
         final long topOut = summaries.stream().mapToLong(TrafficSummary::getBytesOut).sum();
         final long otherIn = grandIn - topIn;
         final long otherOut = grandOut - topOut;
-        if (otherIn > 0 || otherOut > 0) {
-            summaries.add(TrafficSummary.from(OTHER_APPLICATION).withBytes(otherIn, otherOut).build());
-        }
+        // ES always emits the "Other" bucket when includeOther is set, even when it is 0/0.
+        summaries.add(TrafficSummary.from(OTHER_APPLICATION).withBytes(otherIn, otherOut).build());
     }
 
     // Package-private for testing. Escape backslashes before quotes: ClickHouse honours
@@ -434,9 +437,12 @@ public class ClickhouseFlowQueryService implements FlowQueryService {
 
     /** Projects each flow to its conversation key plus the lower/upper endpoint hostname. */
     private String convoProjection(final String whereClause) {
+        // Lower/upper endpoint is decided by the SAME lexicographic string order ConversationKeyUtils
+        // uses to build convo_key, so the lower/upper hostname lines up with the key's lower/upper IP.
+        final String srcIsLower = ipDisplay("src_addr") + " <= " + ipDisplay("dst_addr");
         return "SELECT convo_key AS e,"
-                + " if(src_addr <= dst_addr, src_hostname, dst_hostname) AS lo_hn,"
-                + " if(src_addr <= dst_addr, dst_hostname, src_hostname) AS up_hn,"
+                + " if(" + srcIsLower + ", src_hostname, dst_hostname) AS lo_hn,"
+                + " if(" + srcIsLower + ", dst_hostname, src_hostname) AS up_hn,"
                 + " direction, bytes"
                 + " FROM " + table + " WHERE " + whereClause + " AND convo_key != ''";
     }
@@ -466,9 +472,7 @@ public class ClickhouseFlowQueryService implements FlowQueryService {
         final long grandOut = grand.isEmpty() ? 0L : grand.get(0).getLong("bout");
         final long otherIn = grandIn - summaries.stream().mapToLong(TrafficSummary::getBytesIn).sum();
         final long otherOut = grandOut - summaries.stream().mapToLong(TrafficSummary::getBytesOut).sum();
-        if (otherIn > 0 || otherOut > 0) {
-            summaries.add(TrafficSummary.from(Conversation.forOther().build()).withBytes(otherIn, otherOut).build());
-        }
+        summaries.add(TrafficSummary.from(Conversation.forOther().build()).withBytes(otherIn, otherOut).build());
     }
 
     private Set<String> topNConversations(final int n, final String whereClause) {
@@ -549,8 +553,8 @@ public class ClickhouseFlowQueryService implements FlowQueryService {
 
     @Override
     public CompletableFuture<List<String>> getHosts(final String regex, final long limit, final List<Filter> filters) {
-        final String sql = "SELECT DISTINCT toString(host) AS e FROM " + hostUnion(where(filters))
-                + " WHERE match(toString(host), " + quote(regex) + ") ORDER BY e LIMIT " + limit;
+        final String sql = "SELECT DISTINCT " + ipDisplay("host") + " AS e FROM " + hostUnion(where(filters))
+                + " WHERE match(" + ipDisplay("host") + ", " + quote(regex) + ") ORDER BY e LIMIT " + limit;
         final List<String> hosts = client.queryAll(sql).stream()
                 .map(r -> r.getString("e")).collect(Collectors.toList());
         return CompletableFuture.completedFuture(hosts);
@@ -575,7 +579,7 @@ public class ClickhouseFlowQueryService implements FlowQueryService {
             return CompletableFuture.completedFuture(new ArrayList<>());
         }
         final String w = where(filters);
-        final String sql = hostSummarySelect(w) + " WHERE toString(host) IN (" + quoteAll(hosts) + ")"
+        final String sql = hostSummarySelect(w) + " WHERE " + ipDisplay("host") + " IN (" + quoteAll(hosts) + ")"
                 + " GROUP BY host ORDER BY e";
         final List<TrafficSummary<Host>> summaries = hostSummariesFrom(client.queryAll(sql));
         if (includeOther) {
@@ -607,7 +611,7 @@ public class ClickhouseFlowQueryService implements FlowQueryService {
     }
 
     private String hostSummarySelect(final String whereClause) {
-        return "SELECT toString(host) AS e, anyIf(host_hostname, host_hostname != '') AS hn,"
+        return "SELECT " + ipDisplay("host") + " AS e, anyIf(host_hostname, host_hostname != '') AS hn,"
                 + " sumIf(bytes, direction = 'ingress') AS bin, sumIf(bytes, direction = 'egress') AS bout"
                 + " FROM " + hostUnion(whereClause);
     }
@@ -622,20 +626,20 @@ public class ClickhouseFlowQueryService implements FlowQueryService {
     }
 
     private void appendOtherHost(final List<TrafficSummary<Host>> summaries, final String whereClause) {
+        // Grand total counts each flow ONCE (raw table), not per-endpoint like the host union, so
+        // "Other" = real total minus the shown top-N hosts (matches ES).
         final List<GenericRecord> grand = client.queryAll(
                 "SELECT sumIf(bytes, direction = 'ingress') AS bin, sumIf(bytes, direction = 'egress') AS bout FROM "
-                        + hostUnion(whereClause));
+                        + table + " WHERE " + whereClause);
         final long grandIn = grand.isEmpty() ? 0L : grand.get(0).getLong("bin");
         final long grandOut = grand.isEmpty() ? 0L : grand.get(0).getLong("bout");
         final long otherIn = grandIn - summaries.stream().mapToLong(TrafficSummary::getBytesIn).sum();
         final long otherOut = grandOut - summaries.stream().mapToLong(TrafficSummary::getBytesOut).sum();
-        if (otherIn > 0 || otherOut > 0) {
-            summaries.add(TrafficSummary.from(Host.forOther().build()).withBytes(otherIn, otherOut).build());
-        }
+        summaries.add(TrafficSummary.from(Host.forOther().build()).withBytes(otherIn, otherOut).build());
     }
 
     private Set<String> topNHosts(final int n, final String whereClause) {
-        final String sql = "SELECT toString(host) AS e FROM " + hostUnion(whereClause)
+        final String sql = "SELECT " + ipDisplay("host") + " AS e FROM " + hostUnion(whereClause)
                 + " GROUP BY host ORDER BY sum(bytes) DESC, e LIMIT " + n;
         return client.queryAll(sql).stream().map(r -> r.getString("e"))
                 .collect(Collectors.toCollection(LinkedHashSet::new));
@@ -651,12 +655,13 @@ public class ClickhouseFlowQueryService implements FlowQueryService {
         final String w = where(filters);
         final Map<String, String> hostnames = resolveHostHostnames(hosts, w);
         final Map<Long, double[]> selectedByBucket = includeOther ? new HashMap<>() : null;
-        final String filter = "toString(host) IN (" + quoteAll(hosts) + ")";
+        final String filter = ipDisplay("host") + " IN (" + quoteAll(hosts) + ")";
         for (final GenericRecord r : client.queryAll(seriesSql(hostUnion(w), "host", filter, "1 = 1", range[0], range[1], step))) {
             final boolean ingress = "ingress".equals(r.getString("d"));
             final long bucket = r.getLong("b");
             final double bytes = r.getDouble("bytes");
-            table.put(new Directional<>(host(r.getString("e"), hostnames.get(r.getString("e"))), ingress), bucket, bytes);
+            final String ip = displayIp(r.getString("e"));
+            table.put(new Directional<>(host(ip, hostnames.get(ip)), ingress), bucket, bytes);
             if (includeOther) {
                 selectedByBucket.computeIfAbsent(bucket, k -> new double[2])[ingress ? 0 : 1] += bytes;
             }
@@ -677,8 +682,8 @@ public class ClickhouseFlowQueryService implements FlowQueryService {
 
     private Map<String, String> resolveHostHostnames(final Set<String> hosts, final String whereClause) {
         final Map<String, String> map = new HashMap<>();
-        final String sql = "SELECT toString(host) AS e, anyIf(host_hostname, host_hostname != '') AS hn FROM "
-                + hostUnion(whereClause) + " WHERE toString(host) IN (" + quoteAll(hosts) + ") GROUP BY host";
+        final String sql = "SELECT " + ipDisplay("host") + " AS e, anyIf(host_hostname, host_hostname != '') AS hn FROM "
+                + hostUnion(whereClause) + " WHERE " + ipDisplay("host") + " IN (" + quoteAll(hosts) + ") GROUP BY host";
         for (final GenericRecord r : client.queryAll(sql)) {
             final String hn = r.getString("hn");
             if (hn != null && !hn.isEmpty()) {
@@ -690,6 +695,17 @@ public class ClickhouseFlowQueryService implements FlowQueryService {
 
     private static Host host(final String ip, final String hostname) {
         return (hostname != null && !hostname.isEmpty()) ? new Host(ip, hostname) : new Host(ip);
+    }
+
+    /** SQL: render an IPv6 column as a dotted-quad when it is a v4-mapped address, else as IPv6. */
+    private static String ipDisplay(final String column) {
+        final String s = "toString(" + column + ")";
+        return "if(startsWith(" + s + ", '::ffff:'), substring(" + s + ", 8), " + s + ")";
+    }
+
+    /** Java equivalent of {@link #ipDisplay} for values already read back as strings (series entities). */
+    private static String displayIp(final String ip) {
+        return (ip != null && ip.startsWith("::ffff:")) ? ip.substring("::ffff:".length()) : ip;
     }
 
     @Override

--- a/features/flows/clickhouse/src/test/java/org/opennms/netmgt/flows/clickhouse/ClickhouseFlowQueryIT.java
+++ b/features/flows/clickhouse/src/test/java/org/opennms/netmgt/flows/clickhouse/ClickhouseFlowQueryIT.java
@@ -20,6 +20,7 @@ import org.junit.BeforeClass;
 import org.junit.Test;
 import org.opennms.integration.api.v1.flows.Flow;
 import org.opennms.netmgt.flows.api.Conversation;
+import org.opennms.netmgt.flows.api.Directional;
 import org.opennms.netmgt.flows.api.Host;
 import org.opennms.netmgt.flows.api.TrafficSummary;
 import org.opennms.netmgt.flows.filter.api.Filter;
@@ -31,6 +32,7 @@ import org.testcontainers.utility.DockerImageName;
 
 import com.clickhouse.client.api.Client;
 import com.codahale.metrics.MetricRegistry;
+import com.google.common.collect.Table;
 
 /**
  * Oracle integration test: loads the exact fixture from the Elasticsearch {@code FlowQueryIT} into
@@ -144,6 +146,40 @@ public class ClickhouseFlowQueryIT {
         assertEquals("https", c1.getApplication());
         assertEquals(100, s.get(1).getBytesIn());
         assertEquals(1000, s.get(1).getBytesOut());
+    }
+
+    /** Buckets [10,20,30,40] with the exact proportional https ingress bytes (egress = ×10). */
+    private static final long[] BUCKETS = {10, 20, 30, 40};
+    private static final double[] HTTPS_INGRESS = {
+            75.136476426799, 81.63771712158808, 35.483870967741936, 17.741935483870968};
+
+    @Test
+    public void topNApplicationSeries() throws Exception {
+        // step = 10ms; top-1 app = https. Proportional distribution across the buckets each flow overlaps.
+        final Table<Directional<String>, Long, Double> t =
+                query.getTopNApplicationSeries(1, 10, false, filters()).get();
+        assertEquals(2, t.rowKeySet().size());
+        final Directional<String> in = new Directional<>("https", true);
+        final Directional<String> out = new Directional<>("https", false);
+        for (int i = 0; i < BUCKETS.length; i++) {
+            assertEquals(HTTPS_INGRESS[i], t.get(in, BUCKETS[i]), 1e-8);
+            assertEquals(HTTPS_INGRESS[i] * 10, t.get(out, BUCKETS[i]), 1e-8);
+        }
+    }
+
+    @Test
+    public void topNHostSeries() throws Exception {
+        // top-1 host = 10.1.1.12; its ingress/egress series equal the https series above.
+        final Table<Directional<Host>, Long, Double> t =
+                query.getTopNHostSeries(1, 10, false, filters()).get();
+        assertEquals(2, t.rowKeySet().size());
+        final Host host = new Host("10.1.1.12", "la.le.lu");
+        final Directional<Host> in = new Directional<>(host, true);
+        final Directional<Host> out = new Directional<>(host, false);
+        for (int i = 0; i < BUCKETS.length; i++) {
+            assertEquals(HTTPS_INGRESS[i], t.get(in, BUCKETS[i]), 1e-8);
+            assertEquals(HTTPS_INGRESS[i] * 10, t.get(out, BUCKETS[i]), 1e-8);
+        }
     }
 
     private static void assertSummary(final TrafficSummary<String> s, final String entity,

--- a/features/flows/clickhouse/src/test/java/org/opennms/netmgt/flows/clickhouse/ClickhouseFlowQueryIT.java
+++ b/features/flows/clickhouse/src/test/java/org/opennms/netmgt/flows/clickhouse/ClickhouseFlowQueryIT.java
@@ -1,0 +1,181 @@
+/*
+ * SPDX-License-Identifier: AGPL-3.0-or-later
+ *
+ * Copyright 2026 The OpenNMS Group, Inc.
+ *
+ * Created by Ronny Trommer <ronny@opennms.com>
+ */
+package org.opennms.netmgt.flows.clickhouse;
+
+import static org.junit.Assert.assertEquals;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
+
+import java.time.Instant;
+import java.util.List;
+import java.util.Optional;
+
+import org.junit.AfterClass;
+import org.junit.BeforeClass;
+import org.junit.Test;
+import org.opennms.integration.api.v1.flows.Flow;
+import org.opennms.netmgt.flows.api.Conversation;
+import org.opennms.netmgt.flows.api.Host;
+import org.opennms.netmgt.flows.api.TrafficSummary;
+import org.opennms.netmgt.flows.filter.api.Filter;
+import org.opennms.netmgt.flows.filter.api.SnmpInterfaceIdFilter;
+import org.opennms.netmgt.flows.filter.api.TimeRangeFilter;
+import org.opennms.netmgt.flows.processing.ConversationKeyUtils;
+import org.testcontainers.clickhouse.ClickHouseContainer;
+import org.testcontainers.utility.DockerImageName;
+
+import com.clickhouse.client.api.Client;
+import com.codahale.metrics.MetricRegistry;
+
+/**
+ * Oracle integration test: loads the exact fixture from the Elasticsearch {@code FlowQueryIT} into
+ * ClickHouse and asserts the same expected values through {@link ClickhouseFlowQueryService}. This
+ * pins the ClickHouse read path to the established ES contract — including the {@code Unknown} /
+ * {@code Other} entities, dotted-quad host IPs, and conversation lower/upper hostname mapping.
+ */
+public class ClickhouseFlowQueryIT {
+
+    private static ClickHouseContainer clickhouse;
+    private static Client client;
+    private static ClickhouseFlowQueryService query;
+
+    @BeforeClass
+    public static void setUp() throws Exception {
+        clickhouse = new ClickHouseContainer(DockerImageName.parse("clickhouse/clickhouse-server:24.8"));
+        clickhouse.start();
+        final String host = "localhost".equals(clickhouse.getHost()) ? "127.0.0.1" : clickhouse.getHost();
+        final String endpoint = "http://" + host + ":" + clickhouse.getMappedPort(8123);
+        client = new ClickhouseClientFactory(endpoint, clickhouse.getUsername(), clickhouse.getPassword(), "default")
+                .createClient();
+        new ClickhouseSchemaBootstrap(client, 0).initialize();
+
+        final ClickhouseFlowRepository repository = new ClickhouseFlowRepository(new MetricRegistry(), client, "flows");
+        repository.setBulkSize(1);
+        repository.persist(List.of(
+                flow("http", "192.168.1.100", "10.1.1.11", Flow.Direction.INGRESS, 10, 3, 15, null, null),
+                flow("http", "10.1.1.11", "192.168.1.100", Flow.Direction.EGRESS, 100, 3, 15, null, null),
+                flow("https", "192.168.1.100", "10.1.1.12", Flow.Direction.INGRESS, 100, 13, 26, null, "la.le.lu"),
+                flow("https", "10.1.1.12", "192.168.1.100", Flow.Direction.EGRESS, 1000, 13, 26, "la.le.lu", null),
+                flow("https", "192.168.1.101", "10.1.1.12", Flow.Direction.INGRESS, 110, 14, 45, "ingress.only", "la.le.lu"),
+                flow("https", "10.1.1.12", "192.168.1.101", Flow.Direction.EGRESS, 1100, 14, 45, "la.le.lu", null),
+                flow("", "192.168.1.102", "10.1.1.13", Flow.Direction.INGRESS, 200, 50, 52, null, null),
+                flow("", "10.1.1.13", "192.168.1.102", Flow.Direction.EGRESS, 100, 50, 52, null, null)));
+
+        query = new ClickhouseFlowQueryService(client, "flows");
+    }
+
+    @AfterClass
+    public static void tearDown() {
+        if (client != null) {
+            client.close();
+        }
+        if (clickhouse != null) {
+            clickhouse.stop();
+        }
+    }
+
+    private static List<Filter> filters() {
+        return List.of(new TimeRangeFilter(0, System.currentTimeMillis()), new SnmpInterfaceIdFilter(98));
+    }
+
+    @Test
+    public void flowCount() throws Exception {
+        assertEquals(Long.valueOf(8), query.getFlowCount(filters()).get());
+    }
+
+    @Test
+    public void applications() throws Exception {
+        assertEquals(List.of("http", "https"), query.getApplications("", 10, filters()).get());
+    }
+
+    @Test
+    public void topNApplicationSummaries() throws Exception {
+        final List<TrafficSummary<String>> s = query.getTopNApplicationSummaries(10, true, filters()).get();
+        assertEquals(4, s.size());
+        assertSummary(s.get(0), "https", 210, 2100);
+        assertSummary(s.get(1), "Unknown", 200, 100);
+        assertSummary(s.get(2), "http", 10, 100);
+        assertSummary(s.get(3), "Other", 0, 0);
+
+        final List<TrafficSummary<String>> top1 = query.getTopNApplicationSummaries(1, true, filters()).get();
+        assertEquals(2, top1.size());
+        assertSummary(top1.get(0), "https", 210, 2100);
+        assertSummary(top1.get(1), "Other", 210, 200);
+    }
+
+    @Test
+    public void topNHostSummaries() throws Exception {
+        final List<TrafficSummary<Host>> s = query.getTopNHostSummaries(10, false, filters()).get();
+        assertEquals(6, s.size());
+        assertEquals(new Host("10.1.1.12", "la.le.lu"), s.get(0).getEntity());
+        assertEquals(210, s.get(0).getBytesIn());
+        assertEquals(2100, s.get(0).getBytesOut());
+
+        final List<TrafficSummary<Host>> top1 = query.getTopNHostSummaries(1, true, filters()).get();
+        assertEquals(2, top1.size());
+        assertEquals(new Host("10.1.1.12", "la.le.lu"), top1.get(0).getEntity());
+        assertEquals(Host.forOther().build(), top1.get(1).getEntity());
+        assertEquals(210, top1.get(1).getBytesIn());
+        assertEquals(200, top1.get(1).getBytesOut());
+    }
+
+    @Test
+    public void topNConversationSummaries() throws Exception {
+        final List<TrafficSummary<Conversation>> s = query.getTopNConversationSummaries(2, false, filters()).get();
+        assertEquals(2, s.size());
+
+        final Conversation c0 = s.get(0).getEntity();
+        assertEquals("10.1.1.12", c0.getLowerIp());
+        assertEquals("192.168.1.101", c0.getUpperIp());
+        assertEquals("https", c0.getApplication());
+        assertEquals(Optional.of("la.le.lu"), c0.getLowerHostname());
+        assertEquals(Optional.of("ingress.only"), c0.getUpperHostname());
+        assertEquals(110, s.get(0).getBytesIn());
+        assertEquals(1100, s.get(0).getBytesOut());
+
+        final Conversation c1 = s.get(1).getEntity();
+        assertEquals("10.1.1.12", c1.getLowerIp());
+        assertEquals("192.168.1.100", c1.getUpperIp());
+        assertEquals("https", c1.getApplication());
+        assertEquals(100, s.get(1).getBytesIn());
+        assertEquals(1000, s.get(1).getBytesOut());
+    }
+
+    private static void assertSummary(final TrafficSummary<String> s, final String entity,
+                                      final long in, final long out) {
+        assertEquals(entity, s.getEntity());
+        assertEquals(in, s.getBytesIn());
+        assertEquals(out, s.getBytesOut());
+    }
+
+    private static Flow flow(final String app, final String src, final String dst, final Flow.Direction dir,
+                             final long bytes, final long first, final long last,
+                             final String srcHn, final String dstHn) {
+        final Flow f = mock(Flow.class);
+        when(f.getApplication()).thenReturn(app);
+        when(f.getSrcAddr()).thenReturn(src);
+        when(f.getDstAddr()).thenReturn(dst);
+        when(f.getProtocol()).thenReturn(6);
+        when(f.getDirection()).thenReturn(dir);
+        when(f.getBytes()).thenReturn(bytes);
+        when(f.getFirstSwitched()).thenReturn(Instant.ofEpochMilli(first));
+        when(f.getLastSwitched()).thenReturn(Instant.ofEpochMilli(last));
+        when(f.getTimestamp()).thenReturn(Instant.ofEpochMilli(last));
+        when(f.getLocation()).thenReturn("test");
+        when(f.getSrcAddrHostname()).thenReturn(Optional.ofNullable(srcHn));
+        when(f.getDstAddrHostname()).thenReturn(Optional.ofNullable(dstHn));
+        when(f.getNextHopHostname()).thenReturn(Optional.empty());
+        when(f.getConvoKey()).thenReturn(ConversationKeyUtils.getConvoKeyAsJsonString("test", 6, src, dst, app));
+        if (dir == Flow.Direction.INGRESS) {
+            when(f.getInputSnmp()).thenReturn(98);
+        } else {
+            when(f.getOutputSnmp()).thenReturn(98);
+        }
+        return f;
+    }
+}


### PR DESCRIPTION
## Summary

Pins the ClickHouse read path to the established Elasticsearch `FlowQueryIT` contract with an automated, DB-backed oracle test, and fixes the ES-contract mismatches it surfaced.

`ClickhouseFlowQueryIT` loads the exact `FlowQueryIT` 8-flow fixture into a Testcontainers ClickHouse (via the real `ClickhouseFlowRepository` write path) and asserts the same expected values through `ClickhouseFlowQueryService`: flow count, `getApplications`, and top-N application / host / conversation summaries (including `includeOther`).

## Reconciliation fixes (all verified by the IT)
- Unclassified flows (empty application) surface as the **`Unknown`** entity.
- The **`Other`** bucket is always emitted when `includeOther` is set, even when 0/0 (summaries only; series still drop zero-valued Other points).
- Host IPs render as **dotted-quad** (v4-mapped IPv6 → dotted) across summaries, series, enumeration and filters.
- Host **`Other`** grand total counts each flow **once** (raw table), not per-endpoint like the host union.
- Conversation **lower/upper hostname** mapping uses the same lexicographic string order `ConversationKeyUtils` uses to build `convo_key`.

## Verification
`verify` green: **12 unit + 9 IT tests** against ClickHouse 24.8.

## Follow-up
Extend the oracle IT with the series assertions (exact proportional values to 1e-8), specific-set summaries, `getHosts` regex, partial-time-range, and the unknown-direction variant.

🤖 Generated with [Claude Code](https://claude.com/claude-code)