### PR TITLE
feat(flows): reclassify unknown-direction flows via SNMP interface (ClickHouse)

### DIFF
--- a/features/flows/clickhouse/src/main/java/org/opennms/netmgt/flows/clickhouse/ClickhouseFlowFilters.java
+++ b/features/flows/clickhouse/src/main/java/org/opennms/netmgt/flows/clickhouse/ClickhouseFlowFilters.java
@@ -57,7 +57,13 @@ public final class ClickhouseFlowFilters implements FilterVisitor<String> {
     @Override
     public String visit(final SnmpInterfaceIdFilter f) {
         final int id = f.getSnmpInterfaceId();
-        return "(input_snmp = " + id + " OR output_snmp = " + id + ")";
+        // Match the flow direction to the interface (ES filter_snmp_interface.ftl): ingress uses
+        // input_snmp, egress uses output_snmp, and an unknown-direction flow matches on either. The
+        // query then reclassifies the unknown flow to ingress/egress by which side matched — see
+        // ClickhouseFlowQueryService#directionExpr (ES onms.unknownDirectionScript).
+        return "((direction = 'ingress' AND input_snmp = " + id + ")"
+                + " OR (direction = 'egress' AND output_snmp = " + id + ")"
+                + " OR (direction = 'unknown' AND (input_snmp = " + id + " OR output_snmp = " + id + ")))";
     }
 
     @Override

--- a/features/flows/clickhouse/src/main/java/org/opennms/netmgt/flows/clickhouse/ClickhouseFlowQueryService.java
+++ b/features/flows/clickhouse/src/main/java/org/opennms/netmgt/flows/clickhouse/ClickhouseFlowQueryService.java
@@ -28,6 +28,7 @@ import org.opennms.netmgt.flows.api.LimitedCardinalityField;
 import org.opennms.netmgt.flows.api.TrafficSummary;
 import org.opennms.netmgt.flows.filter.api.ExporterNodeFilter;
 import org.opennms.netmgt.flows.filter.api.Filter;
+import org.opennms.netmgt.flows.filter.api.SnmpInterfaceIdFilter;
 import org.opennms.netmgt.flows.filter.api.TimeRangeFilter;
 import org.opennms.netmgt.flows.processing.ConversationKeyUtils;
 
@@ -124,8 +125,9 @@ public class ClickhouseFlowQueryService implements FlowQueryService {
         }
         final long[] range = timeRange(filters);
         final String w = where(filters);
+        final String dir = directionExpr(filters);
         final List<Map.Entry<String, double[]>> entries =
-                byTotalDesc(proportionalByEntity(table, "application", null, w, range));
+                byTotalDesc(proportionalByEntity(table, "application", null, w, dir, range));
         final int limit = Math.min(n, entries.size());
         final List<TrafficSummary<String>> out = new ArrayList<>(limit + 1);
         final double[] shown = new double[2];
@@ -136,7 +138,7 @@ public class ClickhouseFlowQueryService implements FlowQueryService {
             out.add(appSummary(entries.get(i).getKey(), io));
         }
         if (includeOther) {
-            out.add(otherSummary(OTHER_APPLICATION, shown, proportionalGrand(table, w, range)));
+            out.add(otherSummary(OTHER_APPLICATION, shown, proportionalGrand(table, w, dir, range)));
         }
         return CompletableFuture.completedFuture(out);
     }
@@ -153,8 +155,9 @@ public class ClickhouseFlowQueryService implements FlowQueryService {
         }
         final long[] range = timeRange(filters);
         final String w = where(filters);
+        final String dir = directionExpr(filters);
         final Map<String, double[]> byApp = proportionalByEntity(table, "application",
-                "application IN (" + quoteAll(applications) + ")", w, range);
+                "application IN (" + quoteAll(applications) + ")", w, dir, range);
         final List<TrafficSummary<String>> out = new ArrayList<>();
         final double[] shown = new double[2];
         for (final String app : applications) {              // input-collection order (ES contract)
@@ -167,7 +170,7 @@ public class ClickhouseFlowQueryService implements FlowQueryService {
             out.add(appSummary(app, io));
         }
         if (includeOther) {
-            out.add(otherSummary(OTHER_APPLICATION, shown, proportionalGrand(table, w, range)));
+            out.add(otherSummary(OTHER_APPLICATION, shown, proportionalGrand(table, w, dir, range)));
         }
         return CompletableFuture.completedFuture(out);
     }
@@ -316,11 +319,11 @@ public class ClickhouseFlowQueryService implements FlowQueryService {
      */
     private LinkedHashMap<String, double[]> proportionalByEntity(final String fromExpr, final String entityColumn,
                                                                  final String entityFilter, final String whereClause,
-                                                                 final long[] range) {
+                                                                 final String directionExpr, final long[] range) {
         final long step = Math.max(1, range[1] - range[0]);
         final LinkedHashMap<String, double[]> byEntity = new LinkedHashMap<>();
         for (final GenericRecord r : client.queryAll(
-                seriesSql(fromExpr, entityColumn, entityFilter, whereClause, range[0], range[1], step))) {
+                seriesSql(fromExpr, entityColumn, entityFilter, whereClause, directionExpr, range[0], range[1], step))) {
             byEntity.computeIfAbsent(r.getString("e"), k -> new double[2])
                     ["ingress".equals(r.getString("d")) ? 0 : 1] += r.getDouble("bytes");
         }
@@ -328,11 +331,12 @@ public class ClickhouseFlowQueryService implements FlowQueryService {
     }
 
     /** Proportional grand total {@code [ingress, egress]} over the range as a single bucket. */
-    private double[] proportionalGrand(final String fromExpr, final String whereClause, final long[] range) {
+    private double[] proportionalGrand(final String fromExpr, final String whereClause, final String directionExpr,
+                                       final long[] range) {
         final long step = Math.max(1, range[1] - range[0]);
         final double[] grand = new double[2];
         for (final GenericRecord r : client.queryAll(
-                seriesSql(fromExpr, null, null, whereClause, range[0], range[1], step))) {
+                seriesSql(fromExpr, null, null, whereClause, directionExpr, range[0], range[1], step))) {
             grand["ingress".equals(r.getString("d")) ? 0 : 1] += r.getDouble("bytes");
         }
         return grand;
@@ -406,11 +410,12 @@ public class ClickhouseFlowQueryService implements FlowQueryService {
         }
         final long[] range = timeRange(filters);
         final String w = where(filters);
+        final String dir = directionExpr(filters);
         // selected[bucket] = {ingressSum, egressSum}, only tracked when we need the "Other" residual.
         final Map<Long, double[]> selectedByBucket = includeOther ? new HashMap<>() : null;
 
         final String appFilter = "application IN (" + quoteAll(applications) + ")";
-        for (final GenericRecord r : client.queryAll(seriesSql(this.table, "application", appFilter, w, range[0], range[1], step))) {
+        for (final GenericRecord r : client.queryAll(seriesSql(this.table, "application", appFilter, w, dir, range[0], range[1], step))) {
             final boolean ingress = "ingress".equals(r.getString("d"));
             final long bucket = r.getLong("b");
             final double bytes = r.getDouble("bytes");
@@ -421,7 +426,7 @@ public class ClickhouseFlowQueryService implements FlowQueryService {
         }
 
         if (includeOther) {
-            for (final GenericRecord r : client.queryAll(seriesSql(this.table, null, null, w, range[0], range[1], step))) {
+            for (final GenericRecord r : client.queryAll(seriesSql(this.table, null, null, w, dir, range[0], range[1], step))) {
                 final boolean ingress = "ingress".equals(r.getString("d"));
                 final long bucket = r.getLong("b");
                 final double grand = r.getDouble("bytes");
@@ -452,26 +457,29 @@ public class ClickhouseFlowQueryService implements FlowQueryService {
      * A summary is the single-bucket case: pass {@code step = end - start}.
      */
     private String seriesSql(final String fromExpr, final String entityColumn, final String entityFilter,
-                             final String whereClause, final long start, final long end, final long step) {
+                             final String whereClause, final String directionExpr,
+                             final long start, final long end, final long step) {
         final boolean byEntity = entityColumn != null;
         final String innerEntity = byEntity ? entityColumn + ", " : "";                 // raw column, innermost select
         final String midEntity = byEntity ? "toString(" + entityColumn + ") AS e, " : ""; // stringified in the middle
         final String entityGroup = byEntity ? "e, " : "";
         final String appFilter = (entityFilter != null && !entityFilter.isEmpty()) ? " AND " + entityFilter : "";
+        // Effective direction (reclassifies UNKNOWN flows under an SNMP-interface filter); non-ingress/
+        // egress flows are dropped by the predicate in the innermost WHERE.
         return "WITH " + start + " AS q_start, " + end + " AS q_end, " + step + " AS q_step "
                 + "SELECT " + entityGroup + "d, b, sum(share) AS bytes FROM ("
-                + "  SELECT " + midEntity + "direction AS d, (q_start + i * q_step) AS b,"
+                + "  SELECT " + midEntity + "dir AS d, (q_start + i * q_step) AS b,"
                 + "    if(dur = 0,"
                 + "       if((q_start + i * q_step) <= fs AND fs < least(q_start + (i + 1) * q_step, q_end), toFloat64(bytes_), 0),"
                 + "       toFloat64(bytes_) * greatest(0, least(ls, least(q_start + (i + 1) * q_step, q_end)) - greatest(fs, q_start + i * q_step)) / dur) AS share"
                 + "  FROM ("
-                + "    SELECT " + innerEntity + "direction, bytes AS bytes_,"
+                + "    SELECT " + innerEntity + directionExpr + " AS dir, bytes AS bytes_,"
                 + "      toUnixTimestamp64Milli(first_switched) AS fs, toUnixTimestamp64Milli(last_switched) AS ls,"
                 + "      (toUnixTimestamp64Milli(last_switched) - toUnixTimestamp64Milli(first_switched)) AS dur,"
                 + "      greatest(toUnixTimestamp64Milli(first_switched), q_start) AS lo,"
                 + "      least(toUnixTimestamp64Milli(last_switched), q_end - 1) AS hi,"
                 + "      if(hi >= lo, range(toUInt64(intDiv(lo - q_start, q_step)), toUInt64(intDiv(hi - q_start, q_step)) + 1), emptyArrayUInt64()) AS idxs"
-                + "    FROM " + fromExpr + " WHERE " + whereClause + appFilter + " AND direction IN ('ingress', 'egress')"
+                + "    FROM " + fromExpr + " WHERE " + whereClause + appFilter + " AND " + directionExpr + " IN ('ingress', 'egress')"
                 + "  ) ARRAY JOIN idxs AS i"
                 + ") WHERE share > 0 GROUP BY " + entityGroup + "d, b ORDER BY " + entityGroup + "d, b";
     }
@@ -485,6 +493,35 @@ public class ClickhouseFlowQueryService implements FlowQueryService {
             }
         }
         throw new IllegalArgumentException("A TimeRangeFilter is required for time series queries.");
+    }
+
+    private static Integer snmpInterfaceId(final List<Filter> filters) {
+        if (filters != null) {
+            for (final Filter f : filters) {
+                if (f instanceof SnmpInterfaceIdFilter s) {
+                    return s.getSnmpInterfaceId();
+                }
+            }
+        }
+        return null;
+    }
+
+    /**
+     * SQL expression yielding a flow's effective direction ('ingress'/'egress'/'unknown'). With an
+     * {@link SnmpInterfaceIdFilter} present, an UNKNOWN-direction flow is reclassified by the matched
+     * interface side — input_snmp == id &rarr; ingress, else output_snmp == id &rarr; egress — matching
+     * the ES {@code onms.unknownDirectionScript}. Known directions are kept as stored. Without the
+     * filter it is just the raw {@code direction} column (unknown flows are then dropped by the
+     * ingress/egress predicate in {@link #seriesSql}, as in ES).
+     */
+    private static String directionExpr(final List<Filter> filters) {
+        final Integer snmp = snmpInterfaceId(filters);
+        if (snmp == null) {
+            return "direction";
+        }
+        return "if(direction != 'unknown', toString(direction),"
+                + " if(input_snmp = " + snmp + ", 'ingress',"
+                + " if(output_snmp = " + snmp + ", 'egress', 'unknown')))";
     }
 
     @Override
@@ -512,9 +549,10 @@ public class ClickhouseFlowQueryService implements FlowQueryService {
             final int n, final boolean includeOther, final List<Filter> filters) {
         final long[] range = timeRange(filters);
         final String w = where(filters);
+        final String dir = directionExpr(filters);
         final String cw = w + " AND convo_key != ''";
         final List<Map.Entry<String, double[]>> entries =
-                byTotalDesc(proportionalByEntity(table, "convo_key", null, cw, range));
+                byTotalDesc(proportionalByEntity(table, "convo_key", null, cw, dir, range));
         final int limit = Math.min(n, entries.size());
         final Set<String> shownKeys = new LinkedHashSet<>();
         for (int i = 0; i < limit; i++) {
@@ -536,7 +574,7 @@ public class ClickhouseFlowQueryService implements FlowQueryService {
             out.add(TrafficSummary.from(c).withBytes((long) io[0], (long) io[1]).build());
         }
         if (includeOther) {
-            out.add(otherSummary(Conversation.forOther().build(), shown, proportionalGrand(table, cw, range)));
+            out.add(otherSummary(Conversation.forOther().build(), shown, proportionalGrand(table, cw, dir, range)));
         }
         return CompletableFuture.completedFuture(out);
     }
@@ -549,9 +587,10 @@ public class ClickhouseFlowQueryService implements FlowQueryService {
         }
         final long[] range = timeRange(filters);
         final String w = where(filters);
+        final String dir = directionExpr(filters);
         final String cw = w + " AND convo_key != ''";
         final Map<String, double[]> byConvo = proportionalByEntity(table, "convo_key",
-                "convo_key IN (" + quoteAll(conversations) + ")", cw, range);
+                "convo_key IN (" + quoteAll(conversations) + ")", cw, dir, range);
         final Map<String, String[]> hostnames = resolveConvoHostnames(conversations, w);
         final List<TrafficSummary<Conversation>> out = new ArrayList<>();
         final double[] shown = new double[2];
@@ -570,7 +609,7 @@ public class ClickhouseFlowQueryService implements FlowQueryService {
             out.add(TrafficSummary.from(c).withBytes((long) io[0], (long) io[1]).build());
         }
         if (includeOther) {
-            out.add(otherSummary(Conversation.forOther().build(), shown, proportionalGrand(table, cw, range)));
+            out.add(otherSummary(Conversation.forOther().build(), shown, proportionalGrand(table, cw, dir, range)));
         }
         return CompletableFuture.completedFuture(out);
     }
@@ -616,10 +655,11 @@ public class ClickhouseFlowQueryService implements FlowQueryService {
         }
         final long[] range = timeRange(filters);
         final String w = where(filters);
+        final String dir = directionExpr(filters);
         final Map<String, String[]> hostnames = resolveConvoHostnames(conversations, w);
         final Map<Long, double[]> selectedByBucket = includeOther ? new HashMap<>() : null;
         final String filter = "convo_key IN (" + quoteAll(conversations) + ")";
-        for (final GenericRecord r : client.queryAll(seriesSql(this.table, "convo_key", filter, w, range[0], range[1], step))) {
+        for (final GenericRecord r : client.queryAll(seriesSql(this.table, "convo_key", filter, w, dir, range[0], range[1], step))) {
             final String key = r.getString("e");
             final String[] hn = hostnames.get(key);
             final Conversation c = conversation(key, hn != null ? hn[0] : null, hn != null ? hn[1] : null);
@@ -636,7 +676,7 @@ public class ClickhouseFlowQueryService implements FlowQueryService {
         }
         if (includeOther) {
             for (final GenericRecord r : client.queryAll(
-                    seriesSql(this.table, null, null, w + " AND convo_key != ''", range[0], range[1], step))) {
+                    seriesSql(this.table, null, null, w + " AND convo_key != ''", dir, range[0], range[1], step))) {
                 final boolean ingress = "ingress".equals(r.getString("d"));
                 final long bucket = r.getLong("b");
                 final double other = r.getDouble("bytes")
@@ -694,8 +734,9 @@ public class ClickhouseFlowQueryService implements FlowQueryService {
             final int n, final boolean includeOther, final List<Filter> filters) {
         final long[] range = timeRange(filters);
         final String w = where(filters);
+        final String dir = directionExpr(filters);
         final List<Map.Entry<String, double[]>> entries =
-                byTotalDesc(proportionalByEntity(hostUnion(w), "host", null, "1 = 1", range));
+                byTotalDesc(proportionalByEntity(hostUnion(w), "host", null, "1 = 1", dir, range));
         final int limit = Math.min(n, entries.size());
         final Set<String> shownIps = new LinkedHashSet<>();
         for (int i = 0; i < limit; i++) {
@@ -714,7 +755,7 @@ public class ClickhouseFlowQueryService implements FlowQueryService {
         if (includeOther) {
             // Grand total counts each flow ONCE (raw table), not per-endpoint like the host union, so
             // "Other" = real total minus the shown top-N hosts (matches ES).
-            out.add(otherSummary(Host.forOther().build(), shown, proportionalGrand(table, w, range)));
+            out.add(otherSummary(Host.forOther().build(), shown, proportionalGrand(table, w, dir, range)));
         }
         return CompletableFuture.completedFuture(out);
     }
@@ -727,8 +768,9 @@ public class ClickhouseFlowQueryService implements FlowQueryService {
         }
         final long[] range = timeRange(filters);
         final String w = where(filters);
+        final String dir = directionExpr(filters);
         final Map<String, double[]> byHost = proportionalByEntity(hostUnion(w), "host",
-                ipDisplay("host") + " IN (" + quoteAll(hosts) + ")", "1 = 1", range);
+                ipDisplay("host") + " IN (" + quoteAll(hosts) + ")", "1 = 1", dir, range);
         // Collapse the raw IPv6 keys to their dotted-quad display form (v4-mapped addresses).
         final Map<String, double[]> byIp = new LinkedHashMap<>();
         byHost.forEach((raw, io) -> byIp.merge(displayIp(raw), new double[]{io[0], io[1]},
@@ -746,7 +788,7 @@ public class ClickhouseFlowQueryService implements FlowQueryService {
             out.add(TrafficSummary.from(host(ip, hostnames.get(ip))).withBytes((long) io[0], (long) io[1]).build());
         }
         if (includeOther) {
-            out.add(otherSummary(Host.forOther().build(), shown, proportionalGrand(table, w, range)));
+            out.add(otherSummary(Host.forOther().build(), shown, proportionalGrand(table, w, dir, range)));
         }
         return CompletableFuture.completedFuture(out);
     }
@@ -765,11 +807,15 @@ public class ClickhouseFlowQueryService implements FlowQueryService {
 
     // --- host helpers -----------------------------------------------------
 
-    /** src+dst endpoints unioned so each flow contributes to both its source and destination host. */
+    /**
+     * src+dst endpoints unioned so each flow contributes to both its source and destination host.
+     * input_snmp/output_snmp are carried through so the direction reclassification (D-UNKNOWN) can be
+     * applied to host series/summaries just like the raw-table dimensions.
+     */
     private String hostUnion(final String whereClause) {
-        return "(SELECT src_addr AS host, src_hostname AS host_hostname, direction, bytes, first_switched, last_switched"
+        return "(SELECT src_addr AS host, src_hostname AS host_hostname, direction, input_snmp, output_snmp, bytes, first_switched, last_switched"
                 + " FROM " + table + " WHERE " + whereClause
-                + " UNION ALL SELECT dst_addr AS host, dst_hostname AS host_hostname, direction, bytes, first_switched, last_switched"
+                + " UNION ALL SELECT dst_addr AS host, dst_hostname AS host_hostname, direction, input_snmp, output_snmp, bytes, first_switched, last_switched"
                 + " FROM " + table + " WHERE " + whereClause + ")";
     }
 
@@ -788,10 +834,11 @@ public class ClickhouseFlowQueryService implements FlowQueryService {
         }
         final long[] range = timeRange(filters);
         final String w = where(filters);
+        final String dir = directionExpr(filters);
         final Map<String, String> hostnames = resolveHostHostnames(hosts, w);
         final Map<Long, double[]> selectedByBucket = includeOther ? new HashMap<>() : null;
         final String filter = ipDisplay("host") + " IN (" + quoteAll(hosts) + ")";
-        for (final GenericRecord r : client.queryAll(seriesSql(hostUnion(w), "host", filter, "1 = 1", range[0], range[1], step))) {
+        for (final GenericRecord r : client.queryAll(seriesSql(hostUnion(w), "host", filter, "1 = 1", dir, range[0], range[1], step))) {
             final boolean ingress = "ingress".equals(r.getString("d"));
             final long bucket = r.getLong("b");
             final double bytes = r.getDouble("bytes");
@@ -802,7 +849,7 @@ public class ClickhouseFlowQueryService implements FlowQueryService {
             }
         }
         if (includeOther) {
-            for (final GenericRecord r : client.queryAll(seriesSql(hostUnion(w), null, null, "1 = 1", range[0], range[1], step))) {
+            for (final GenericRecord r : client.queryAll(seriesSql(hostUnion(w), null, null, "1 = 1", dir, range[0], range[1], step))) {
                 final boolean ingress = "ingress".equals(r.getString("d"));
                 final long bucket = r.getLong("b");
                 final double other = r.getDouble("bytes")
@@ -863,7 +910,8 @@ public class ClickhouseFlowQueryService implements FlowQueryService {
                                                                              final List<Filter> filters) {
         final String col = fieldColumn(field);
         final long[] range = timeRange(filters);
-        final Map<String, double[]> byValue = proportionalByEntity(table, col, null, where(filters), range);
+        final Map<String, double[]> byValue =
+                proportionalByEntity(table, col, null, where(filters), directionExpr(filters), range);
         // A limited-cardinality field returns every value in ascending field-value order; no top-N / "Other".
         final List<Map.Entry<String, double[]>> entries = new ArrayList<>(byValue.entrySet());
         entries.sort(Comparator.comparingInt(e -> Integer.parseInt(e.getKey())));
@@ -881,7 +929,8 @@ public class ClickhouseFlowQueryService implements FlowQueryService {
         final String col = fieldColumn(field);
         final long[] range = timeRange(filters);
         final Table<Directional<String>, Long, Double> table = HashBasedTable.create();
-        for (final GenericRecord r : client.queryAll(seriesSql(this.table, col, null, where(filters), range[0], range[1], step))) {
+        for (final GenericRecord r : client.queryAll(
+                seriesSql(this.table, col, null, where(filters), directionExpr(filters), range[0], range[1], step))) {
             table.put(new Directional<>(r.getString("e"), "ingress".equals(r.getString("d"))),
                       r.getLong("b"), r.getDouble("bytes"));
         }

--- a/features/flows/clickhouse/src/test/java/org/opennms/netmgt/flows/clickhouse/ClickhouseFlowFiltersTest.java
+++ b/features/flows/clickhouse/src/test/java/org/opennms/netmgt/flows/clickhouse/ClickhouseFlowFiltersTest.java
@@ -38,7 +38,10 @@ public class ClickhouseFlowFiltersTest {
     public void dscpSnmpAndExporterNode() {
         assertEquals("dscp IN (1, 46)",
                 ClickhouseFlowFilters.whereClause(List.of(new DscpFilter(List.of(1, 46)))));
-        assertEquals("(input_snmp = 5 OR output_snmp = 5)",
+        // Direction-aware match (ES filter_snmp_interface): ingress->input, egress->output, unknown->either.
+        assertEquals("((direction = 'ingress' AND input_snmp = 5)"
+                        + " OR (direction = 'egress' AND output_snmp = 5)"
+                        + " OR (direction = 'unknown' AND (input_snmp = 5 OR output_snmp = 5)))",
                 ClickhouseFlowFilters.whereClause(List.of(new SnmpInterfaceIdFilter(5))));
         assertEquals("exporter_node = 42",
                 ClickhouseFlowFilters.whereClause(List.of(new ExporterNodeFilter(new NodeCriteria(42)))));
@@ -50,7 +53,7 @@ public class ClickhouseFlowFiltersTest {
         final String where = ClickhouseFlowFilters.whereClause(filters);
         assertTrue(where.contains(" AND "));
         assertTrue(where.startsWith("(first_switched <="));
-        assertTrue(where.endsWith("(input_snmp = 7 OR output_snmp = 7)"));
+        assertTrue(where.endsWith("(direction = 'unknown' AND (input_snmp = 7 OR output_snmp = 7)))"));
     }
 
     @Test(expected = UnsupportedOperationException.class)

--- a/features/flows/clickhouse/src/test/java/org/opennms/netmgt/flows/clickhouse/ClickhouseUnknownDirectionIT.java
+++ b/features/flows/clickhouse/src/test/java/org/opennms/netmgt/flows/clickhouse/ClickhouseUnknownDirectionIT.java
@@ -1,0 +1,152 @@
+/*
+ * SPDX-License-Identifier: AGPL-3.0-or-later
+ *
+ * Copyright 2026 The OpenNMS Group, Inc.
+ *
+ * Created by Ronny Trommer <ronny@opennms.com>
+ */
+package org.opennms.netmgt.flows.clickhouse;
+
+import static org.junit.Assert.assertEquals;
+
+import java.time.Instant;
+import java.util.List;
+import java.util.Optional;
+
+import org.junit.AfterClass;
+import org.junit.BeforeClass;
+import org.junit.Test;
+import org.opennms.integration.api.v1.flows.Flow;
+import org.opennms.netmgt.flows.api.Host;
+import org.opennms.netmgt.flows.api.TrafficSummary;
+import org.opennms.netmgt.flows.filter.api.Filter;
+import org.opennms.netmgt.flows.filter.api.SnmpInterfaceIdFilter;
+import org.opennms.netmgt.flows.filter.api.TimeRangeFilter;
+import org.opennms.netmgt.flows.processing.ConversationKeyUtils;
+import org.testcontainers.clickhouse.ClickHouseContainer;
+import org.testcontainers.utility.DockerImageName;
+
+import com.clickhouse.client.api.Client;
+import com.codahale.metrics.MetricRegistry;
+
+/**
+ * Pins the unknown-direction reclassification (D-UNKNOWN, ES {@code onms.unknownDirectionScript}):
+ * with an {@link SnmpInterfaceIdFilter} present, an UNKNOWN-direction flow is counted as ingress when
+ * its {@code input_snmp} matches and as egress when its {@code output_snmp} matches. The two https
+ * flows that {@code FlowQueryIT} marks UNKNOWN (input_snmp 98/100 and 100/98) must therefore produce
+ * exactly the same https totals (210/2100) as the known-direction fixture. Without the SNMP filter
+ * the unknown flows are dropped from the ingress/egress split entirely (matching ES).
+ */
+public class ClickhouseUnknownDirectionIT {
+
+    private static ClickHouseContainer clickhouse;
+    private static Client client;
+    private static ClickhouseFlowQueryService query;
+
+    @BeforeClass
+    public static void setUp() throws Exception {
+        clickhouse = new ClickHouseContainer(DockerImageName.parse("clickhouse/clickhouse-server:24.8"));
+        clickhouse.start();
+        final String host = "localhost".equals(clickhouse.getHost()) ? "127.0.0.1" : clickhouse.getHost();
+        final String endpoint = "http://" + host + ":" + clickhouse.getMappedPort(8123);
+        client = new ClickhouseClientFactory(endpoint, clickhouse.getUsername(), clickhouse.getPassword(), "default")
+                .createClient();
+        new ClickhouseSchemaBootstrap(client, 0).initialize();
+
+        final ClickhouseFlowRepository repository = new ClickhouseFlowRepository(new MetricRegistry(), client, "flows");
+        repository.setBulkSize(1);
+        // Same fixture as ClickhouseFlowQueryIT, except the two [13,26] https flows are UNKNOWN with the
+        // input/output SNMP ids from FlowQueryIT.getFlowSet(true): flow-in input=98, flow-out output=98.
+        repository.persist(List.of(
+                flow("http", "192.168.1.100", "10.1.1.11", Flow.Direction.INGRESS, 10, 3, 15, null, null, 98, 0),
+                flow("http", "10.1.1.11", "192.168.1.100", Flow.Direction.EGRESS, 100, 3, 15, null, null, 0, 98),
+                flow("https", "192.168.1.100", "10.1.1.12", Flow.Direction.UNKNOWN, 100, 13, 26, null, "la.le.lu", 98, 100),
+                flow("https", "10.1.1.12", "192.168.1.100", Flow.Direction.UNKNOWN, 1000, 13, 26, "la.le.lu", null, 100, 98),
+                flow("https", "192.168.1.101", "10.1.1.12", Flow.Direction.INGRESS, 110, 14, 45, "ingress.only", "la.le.lu", 98, 0),
+                flow("https", "10.1.1.12", "192.168.1.101", Flow.Direction.EGRESS, 1100, 14, 45, "la.le.lu", null, 0, 98),
+                flow("", "192.168.1.102", "10.1.1.13", Flow.Direction.INGRESS, 200, 50, 52, null, null, 98, 0),
+                flow("", "10.1.1.13", "192.168.1.102", Flow.Direction.EGRESS, 100, 50, 52, null, null, 0, 98)));
+
+        query = new ClickhouseFlowQueryService(client, "flows");
+    }
+
+    @AfterClass
+    public static void tearDown() {
+        if (client != null) {
+            client.close();
+        }
+        if (clickhouse != null) {
+            clickhouse.stop();
+        }
+    }
+
+    private static List<Filter> withSnmp() {
+        return List.of(new TimeRangeFilter(0, System.currentTimeMillis()), new SnmpInterfaceIdFilter(98));
+    }
+
+    private static List<Filter> noSnmp() {
+        return List.of(new TimeRangeFilter(0, System.currentTimeMillis()));
+    }
+
+    @Test
+    public void snmpFilterMatchesUnknownFlows() throws Exception {
+        // The four-branch SNMP filter includes the UNKNOWN flows (input_snmp=98 / output_snmp=98).
+        assertEquals(Long.valueOf(8), query.getFlowCount(withSnmp()).get());
+    }
+
+    @Test
+    public void applicationSummaryReclassifiesUnknownUnderSnmpFilter() throws Exception {
+        // flow-in (input_snmp=98) -> ingress 100, flow-out (output_snmp=98) -> egress 1000, plus the
+        // known https flows 110/1100 = 210/2100, identical to the known-direction fixture.
+        final List<TrafficSummary<String>> s = query.getTopNApplicationSummaries(1, false, withSnmp()).get();
+        assertEquals(1, s.size());
+        assertEquals("https", s.get(0).getEntity());
+        assertEquals(210, s.get(0).getBytesIn());
+        assertEquals(2100, s.get(0).getBytesOut());
+    }
+
+    @Test
+    public void hostSummaryReclassifiesUnknownUnderSnmpFilter() throws Exception {
+        // 10.1.1.12 is an endpoint of both UNKNOWN https flows; reclassification must flow through the
+        // host union too (input_snmp/output_snmp carried into hostUnion).
+        final List<TrafficSummary<Host>> s = query.getTopNHostSummaries(1, false, withSnmp()).get();
+        assertEquals(1, s.size());
+        assertEquals(new Host("10.1.1.12", "la.le.lu"), s.get(0).getEntity());
+        assertEquals(210, s.get(0).getBytesIn());
+        assertEquals(2100, s.get(0).getBytesOut());
+    }
+
+    @Test
+    public void unknownFlowsDroppedWithoutSnmpFilter() throws Exception {
+        // With no SNMP filter there is nothing to reclassify by, so the UNKNOWN flows are excluded from
+        // the ingress/egress split — only the known https flows (110/1100) remain.
+        final List<TrafficSummary<String>> s = query.getTopNApplicationSummaries(1, false, noSnmp()).get();
+        assertEquals(1, s.size());
+        assertEquals("https", s.get(0).getEntity());
+        assertEquals(110, s.get(0).getBytesIn());
+        assertEquals(1100, s.get(0).getBytesOut());
+    }
+
+    private static Flow flow(final String app, final String src, final String dst, final Flow.Direction dir,
+                             final long bytes, final long first, final long last,
+                             final String srcHn, final String dstHn, final int inSnmp, final int outSnmp) {
+        final Flow f = org.mockito.Mockito.mock(Flow.class);
+        org.mockito.Mockito.when(f.getApplication()).thenReturn(app);
+        org.mockito.Mockito.when(f.getSrcAddr()).thenReturn(src);
+        org.mockito.Mockito.when(f.getDstAddr()).thenReturn(dst);
+        org.mockito.Mockito.when(f.getProtocol()).thenReturn(6);
+        org.mockito.Mockito.when(f.getDirection()).thenReturn(dir);
+        org.mockito.Mockito.when(f.getBytes()).thenReturn(bytes);
+        org.mockito.Mockito.when(f.getFirstSwitched()).thenReturn(Instant.ofEpochMilli(first));
+        org.mockito.Mockito.when(f.getLastSwitched()).thenReturn(Instant.ofEpochMilli(last));
+        org.mockito.Mockito.when(f.getTimestamp()).thenReturn(Instant.ofEpochMilli(last));
+        org.mockito.Mockito.when(f.getLocation()).thenReturn("test");
+        org.mockito.Mockito.when(f.getSrcAddrHostname()).thenReturn(Optional.ofNullable(srcHn));
+        org.mockito.Mockito.when(f.getDstAddrHostname()).thenReturn(Optional.ofNullable(dstHn));
+        org.mockito.Mockito.when(f.getNextHopHostname()).thenReturn(Optional.empty());
+        org.mockito.Mockito.when(f.getConvoKey()).thenReturn(ConversationKeyUtils.getConvoKeyAsJsonString("test", 6, src, dst, app));
+        org.mockito.Mockito.when(f.getInputSnmp()).thenReturn(inSnmp);
+        org.mockito.Mockito.when(f.getOutputSnmp()).thenReturn(outSnmp);
+        return f;
+    }
+}


### PR DESCRIPTION
## What

Ports the last `FlowQueryIT`-contract gap to the ClickHouse read path: **unknown-direction reclassification** (ES `onms.unknownDirectionScript` + `filter_snmp_interface.ftl`). Two independent mechanisms, mirroring ES:

### Inclusion (WHERE)
`SnmpInterfaceIdFilter(X)` now matches the flow direction to the interface side:
```
(ingress AND input_snmp=X) OR (egress AND output_snmp=X) OR (unknown AND (input_snmp=X OR output_snmp=X))
```
replacing the too-broad `input_snmp=X OR output_snmp=X`. For known-direction flows this is equivalent, so existing assertions are unchanged.

### Direction assignment (grouping)
A new `directionExpr()` computes each flow's **effective** direction. An `UNKNOWN` flow under the SNMP filter becomes `ingress` when `input_snmp=X` and `egress` when `output_snmp=X`; known directions are kept. It's threaded through `seriesSql` and the proportional summary helpers, so **every** dimension (application/host/conversation/field, summaries + series) reclassifies consistently. `hostUnion` now carries `input_snmp`/`output_snmp` so the host dimension reclassifies too.

Without an SNMP filter there's nothing to reclassify by, so unknown flows stay dropped from the ingress/egress split (matching ES).

## Tests
New `ClickhouseUnknownDirectionIT` loads the `FlowQueryIT` unknown-direction fixture (the two `[13,26]` https flows marked `UNKNOWN`, input/output SNMP `98/100` and `100/98`):
- **app** top-1 summary under `SnmpInterfaceIdFilter(98)` → `https 210/2100` (identical to the known-direction fixture — reclassification recovers ingress 100 + egress 1000).
- **host** top-1 summary → `Host(10.1.1.12, la.le.lu) 210/2100` (proves reclassification through the host union).
- without the SNMP filter → `https 110/1100` (unknown flows dropped).
- `getFlowCount` under the filter → `8` (four-branch inclusion matches the unknown flows).

Updated `ClickhouseFlowFiltersTest` for the four-branch SNMP SQL. **20 ITs + 12 unit tests green** locally against a real ClickHouse.

## Status
This completes the four FlowQueryIT assertions requested (specific-set + getHosts regex in #172, partial-range proportional summaries in #173, unknown-direction here). Remaining ClickHouse phases: 3.8 register the service as `FlowQueryService` + health check; phase 6 wire the feature into `features.xml` to make it live; phase 7 docs.

🤖 Generated with [Claude Code](https://claude.com/claude-code)