### PR TITLE
feat(flows): register ClickhouseFlowQueryService + ClickHouse health check (3.8)

### DIFF
--- a/features/flows/clickhouse/src/main/java/org/opennms/netmgt/flows/clickhouse/ClickhouseHealthCheck.java
+++ b/features/flows/clickhouse/src/main/java/org/opennms/netmgt/flows/clickhouse/ClickhouseHealthCheck.java
@@ -1,0 +1,80 @@
+/*
+ * SPDX-License-Identifier: AGPL-3.0-or-later
+ *
+ * Copyright 2026 The OpenNMS Group, Inc.
+ *
+ * Created by Ronny Trommer <ronny@opennms.com>
+ */
+package org.opennms.netmgt.flows.clickhouse;
+
+import java.io.IOException;
+import java.util.List;
+import java.util.Objects;
+
+import org.opennms.core.health.api.Context;
+import org.opennms.core.health.api.HealthCheck;
+import org.opennms.core.health.api.Response;
+import org.opennms.core.health.api.Status;
+import org.osgi.service.cm.Configuration;
+import org.osgi.service.cm.ConfigurationAdmin;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import com.clickhouse.client.api.Client;
+
+/**
+ * Health check for ClickHouse flow persistence connectivity. Runs a trivial {@code SELECT 1} against
+ * the configured server. Mirrors the Elasticsearch {@code RequireConfigurationElasticHealthCheck}:
+ * if the feature is installed but not configured (no ConfigAdmin properties for the flow-persistence
+ * PID) the check reports success with "Not configured" rather than a spurious failure.
+ */
+public class ClickhouseHealthCheck implements HealthCheck {
+
+    private static final Logger LOG = LoggerFactory.getLogger(ClickhouseHealthCheck.class);
+    private static final String CLICKHOUSE = "clickhouse";
+
+    private final Client client;
+    private final String featureName;
+    private final ConfigurationAdmin configAdmin;
+    private final String pid;
+
+    public ClickhouseHealthCheck(final Client client, final String featureName,
+                                 final ConfigurationAdmin configAdmin, final String pid) {
+        this.client = Objects.requireNonNull(client);
+        this.featureName = Objects.requireNonNull(featureName);
+        this.configAdmin = Objects.requireNonNull(configAdmin);
+        this.pid = Objects.requireNonNull(pid);
+    }
+
+    @Override
+    public String getDescription() {
+        return "ClickHouse connectivity health check for " + featureName;
+    }
+
+    @Override
+    public List<String> getTags() {
+        return List.of(CLICKHOUSE);
+    }
+
+    @Override
+    public Response perform(final Context context) {
+        // If the feature is installed but not configured, don't report a failure.
+        try {
+            final Configuration configuration = configAdmin.getConfiguration(pid);
+            if (configuration.getProperties() == null) {
+                return new Response(Status.Success, "Not configured");
+            }
+        } catch (final IOException e) {
+            return new Response(e);
+        }
+
+        try {
+            client.queryAll("SELECT 1");
+            return new Response(Status.Success, "ClickHouse is reachable for " + featureName);
+        } catch (final Exception e) {
+            LOG.error("Failed to check ClickHouse health", e);
+            return new Response(Status.Failure,
+                    "Failed to connect to ClickHouse for " + featureName + ": " + e.getMessage());
+        }
+    }
+}

--- a/features/flows/clickhouse/src/main/resources/OSGI-INF/blueprint/blueprint.xml
+++ b/features/flows/clickhouse/src/main/resources/OSGI-INF/blueprint/blueprint.xml
@@ -7,10 +7,9 @@
     Created by Ronny Trommer <ronny@opennms.com>
 
     ClickHouse flow persistence + query (flow-persistence-clickhouse).
-    Skeleton: config PID defaults are declared here. The schema bootstrap,
-    the Path A ClickhouseFlowRepository (FlowRepository, flows.repository.id=clickhouse),
-    the ClickhouseFlowQueryService (FlowQueryService), and the health check are added in
-    tasks 1.5, 2.4, 3.8 respectively.
+    Config PID defaults, the schema bootstrap, the Path A ClickhouseFlowRepository
+    (FlowRepository, flows.repository.id=clickhouse), the ClickhouseFlowQueryService
+    (FlowQueryService) and the ClickHouse health check are all declared here.
 -->
 <blueprint xmlns="http://www.osgi.org/xmlns/blueprint/v1.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
            xmlns:cm="http://aries.apache.org/blueprint/xmlns/blueprint-cm/v1.1.0"
@@ -84,6 +83,24 @@
         <service-properties>
             <entry key="flows.repository.id" value="clickhouse"/>
         </service-properties>
+    </service>
+
+    <!-- Read path: the ClickHouse-backed FlowQueryService (defaults are sane; rollup routing off). -->
+    <bean id="clickhouseFlowQueryService" class="org.opennms.netmgt.flows.clickhouse.ClickhouseFlowQueryService">
+        <argument ref="clickhouseClient"/>
+        <argument value="${table}"/>
+    </bean>
+    <service interface="org.opennms.netmgt.flows.api.FlowQueryService" ref="clickhouseFlowQueryService"/>
+
+    <!-- Health check: SELECT 1 against ClickHouse; reports "Not configured" when the PID is unset. -->
+    <reference id="configurationAdmin" interface="org.osgi.service.cm.ConfigurationAdmin"/>
+    <service interface="org.opennms.core.health.api.HealthCheck">
+        <bean class="org.opennms.netmgt.flows.clickhouse.ClickhouseHealthCheck">
+            <argument ref="clickhouseClient"/>
+            <argument value="Flows"/>
+            <argument ref="configurationAdmin"/>
+            <argument value="org.opennms.features.flows.persistence.clickhouse"/>
+        </bean>
     </service>
 
 </blueprint>

--- a/features/flows/clickhouse/src/test/java/org/opennms/netmgt/flows/clickhouse/ClickhouseHealthCheckTest.java
+++ b/features/flows/clickhouse/src/test/java/org/opennms/netmgt/flows/clickhouse/ClickhouseHealthCheckTest.java
@@ -1,0 +1,92 @@
+/*
+ * SPDX-License-Identifier: AGPL-3.0-or-later
+ *
+ * Copyright 2026 The OpenNMS Group, Inc.
+ *
+ * Created by Ronny Trommer <ronny@opennms.com>
+ */
+package org.opennms.netmgt.flows.clickhouse;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertTrue;
+import static org.mockito.ArgumentMatchers.anyString;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.verifyNoInteractions;
+import static org.mockito.Mockito.when;
+
+import java.io.IOException;
+import java.util.Hashtable;
+import java.util.List;
+
+import org.junit.Test;
+import org.opennms.core.health.api.Response;
+import org.opennms.core.health.api.Status;
+import org.osgi.service.cm.Configuration;
+import org.osgi.service.cm.ConfigurationAdmin;
+
+import com.clickhouse.client.api.Client;
+
+public class ClickhouseHealthCheckTest {
+
+    private static final String PID = "org.opennms.features.flows.persistence.clickhouse";
+
+    @Test
+    public void reportsSuccessWhenNotConfigured() throws Exception {
+        final Client client = mock(Client.class);
+        final Configuration config = mock(Configuration.class);
+        when(config.getProperties()).thenReturn(null); // no ConfigAdmin properties yet
+        final ConfigurationAdmin configAdmin = mock(ConfigurationAdmin.class);
+        when(configAdmin.getConfiguration(PID)).thenReturn(config);
+
+        final Response r = new ClickhouseHealthCheck(client, "Flows", configAdmin, PID).perform(null);
+
+        assertEquals(Status.Success, r.getStatus());
+        assertEquals("Not configured", r.getMessage());
+        verifyNoInteractions(client); // must not touch ClickHouse when unconfigured
+    }
+
+    @Test
+    public void reportsSuccessWhenReachable() throws Exception {
+        final Client client = mock(Client.class);
+        when(client.queryAll("SELECT 1")).thenReturn(List.of());
+        final ClickhouseHealthCheck check = configuredCheck(client);
+
+        final Response r = check.perform(null);
+
+        assertTrue(r.isSuccess());
+        assertTrue(r.getMessage().contains("reachable"));
+    }
+
+    @Test
+    public void reportsFailureWhenUnreachable() throws Exception {
+        final Client client = mock(Client.class);
+        when(client.queryAll(anyString())).thenThrow(new RuntimeException("connection refused"));
+        final ClickhouseHealthCheck check = configuredCheck(client);
+
+        final Response r = check.perform(null);
+
+        assertEquals(Status.Failure, r.getStatus());
+        assertTrue(r.getMessage().contains("connection refused"));
+    }
+
+    @Test
+    public void reportsFailureWhenConfigAdminThrows() throws Exception {
+        final Client client = mock(Client.class);
+        final ConfigurationAdmin configAdmin = mock(ConfigurationAdmin.class);
+        when(configAdmin.getConfiguration(PID)).thenThrow(new IOException("configadmin unavailable"));
+
+        final Response r = new ClickhouseHealthCheck(client, "Flows", configAdmin, PID).perform(null);
+
+        assertEquals(Status.Failure, r.getStatus());
+        assertTrue(r.getMessage().contains("configadmin unavailable"));
+        verifyNoInteractions(client);
+    }
+
+    private static ClickhouseHealthCheck configuredCheck(final Client client) throws Exception {
+        final Configuration config = mock(Configuration.class);
+        when(config.getProperties()).thenReturn(new Hashtable<>()); // non-null -> configured
+        final ConfigurationAdmin configAdmin = mock(ConfigurationAdmin.class);
+        when(configAdmin.getConfiguration(PID)).thenReturn(config);
+        return new ClickhouseHealthCheck(client, "Flows", configAdmin, PID);
+    }
+}


### PR DESCRIPTION
## What

ClickHouse task **3.8** — wire the read path into OSGi. The module blueprint already published the write side (`FlowRepository`, `flows.repository.id=clickhouse`); this adds:

- **`ClickhouseFlowQueryService`** published as `org.opennms.netmgt.flows.api.FlowQueryService` (constructor: the shared `clickhouseClient` + `${table}`; rollup routing off by default).
- **`ClickhouseHealthCheck`** (`org.opennms.core.health.api.HealthCheck`): runs `SELECT 1`, and — mirroring ES `RequireConfigurationElasticHealthCheck` — returns `"Not configured"` (Success) when the flow-persistence PID has no ConfigAdmin properties. Folds the ES base+guard two-class split into one class (the unguarded check is never registered standalone here).

No pom changes needed (`osgi.cmpn` + `core.health.api` already present). Verified the generated bundle manifest imports `core.health.api` / `flows.api` / `osgi.service.cm` and publishes `FlowQueryService` + `HealthCheck` with `Bundle-Blueprint` set.

## Tests
`ClickhouseHealthCheckTest` covers all four `perform()` branches — not-configured, reachable, unreachable, and ConfigAdmin `IOException`. **4 unit tests green**; module bundles cleanly.

## Review notes (from `/code-review`)
- **Phase-6 constraint:** while ES is still present, both features register a `FlowQueryService` at ranking 0 and the `flows/rest` + `datachoices` references are unfiltered — so the two bundles must not be co-installed. The clickhouse bundle is **not** in `features.xml` yet; phase 6 wires it in and *removes* the ES flow module, leaving a single service. (No speculative ranking added — ES has none and the target is single-backend.)
- **Follow-ons (pre-existing, task 1.5; not in scope here):** the `ClickhouseClientFactory` sets no connect/read timeout (mirror ES 5s/30s), and the eager schema bootstrap means an unconfigured+unreachable server fails bundle startup before the health check can report gracefully.

## Next ClickHouse phases
Phase 6 (wire feature into `features.xml` + delete the ES flow module — makes ClickHouse live), phase 7 (docs/release).

🤖 Generated with [Claude Code](https://claude.com/claude-code)