### PR TITLE
build(flows): hoist ClickHouse client versions + add opennms-clickhouse-client feature

### DIFF
--- a/container/features/src/main/resources/features.xml
+++ b/container/features/src/main/resources/features.xml
@@ -1705,4 +1705,25 @@
         <bundle>mvn:org.apache.httpcomponents/httpasyncclient-osgi/${httpasyncclientVersion}</bundle>
     </feature>
 
+    <feature name="opennms-clickhouse-client" description="OpenNMS :: ClickHouse Client" version="${project.version}">
+        <!-- Already-OSGi deps reused from existing features. -->
+        <feature>jackson-core</feature>
+        <feature>commons-codec</feature>
+        <feature>commons-io</feature>
+        <feature>commons-compress</feature>
+        <bundle>mvn:org.ow2.asm/asm/${asmVersion}</bundle>
+        <bundle>mvn:at.yawk.lz4/lz4-java/${lz4JavaVersion}</bundle>
+        <!-- Plain jars (no OSGi manifest) wrapped on install. ClickHouse's client-v2 stack pulls
+             HttpComponents 5.x (disjoint from the 4.x used by opennms-elastic-client). -->
+        <bundle>wrap:mvn:org.apache.httpcomponents.core5/httpcore5/${httpcore5Version}</bundle>
+        <bundle>wrap:mvn:org.apache.httpcomponents.core5/httpcore5-h2/${httpcore5Version}</bundle>
+        <bundle>wrap:mvn:org.apache.httpcomponents.client5/httpclient5/${httpclient5Version}</bundle>
+        <bundle>wrap:mvn:org.roaringbitmap/RoaringBitmap/${roaringbitmapVersion}</bundle>
+        <bundle>wrap:mvn:org.roaringbitmap/shims/${roaringbitmapVersion}</bundle>
+        <bundle>wrap:mvn:org.jspecify/jspecify/${jspecifyVersion}</bundle>
+        <bundle>wrap:mvn:com.clickhouse/clickhouse-data/${clickhouseClientVersion}</bundle>
+        <bundle>wrap:mvn:com.clickhouse/clickhouse-client/${clickhouseClientVersion}</bundle>
+        <bundle>wrap:mvn:com.clickhouse/client-v2/${clickhouseClientVersion}</bundle>
+    </feature>
+
 </features>

--- a/features/flows/clickhouse/pom.xml
+++ b/features/flows/clickhouse/pom.xml
@@ -12,8 +12,9 @@
   <name>OpenNMS :: Features :: Flows :: ClickHouse</name>
   <properties>
     <skipITs>true</skipITs>
-    <!-- TODO(1.2): hoist to root pom / dependencies BOM once spike 0.1 confirms OSGi bundling. -->
-    <clickhouseClientVersion>0.8.6</clickhouseClientVersion>
+    <!-- clickhouseClientVersion (and the httpclient5/httpcore5/roaringbitmap/jspecify pins used by the
+         opennms-clickhouse-client Karaf feature) are defined in the root pom so the module and the
+         feature stay in lockstep. -->
   </properties>
   <build>
     <plugins>

--- a/pom.xml
+++ b/pom.xml
@@ -1734,6 +1734,13 @@
     <camelVersion>2.21.5</camelVersion>
     <!-- Match (or beat) Newts version -->
     <cassandraVersion>4.17.0</cassandraVersion>
+    <!-- ClickHouse flow-persistence client stack (features/flows/clickhouse + opennms-clickhouse-client feature).
+         Versions track com.clickhouse:client-v2's transitive tree; keep in lockstep with the feature bundles. -->
+    <clickhouseClientVersion>0.8.6</clickhouseClientVersion>
+    <httpclient5Version>5.3.1</httpclient5Version>
+    <httpcore5Version>5.2.4</httpcore5Version>
+    <roaringbitmapVersion>0.9.47</roaringbitmapVersion>
+    <jspecifyVersion>0.3.0</jspecifyVersion>
     <cloverVersion>3.2.0</cloverVersion>
     <commonsBeanutilsVersion>1.11.0</commonsBeanutilsVersion>
     <commonsChainVersion>1.2</commonsChainVersion>


### PR DESCRIPTION
## What

**Phase 6, PR B** — prep for the ClickHouse cut-over. Additive; installs nothing into the running flows path yet.

1. **Hoist versions to the root pom.** Move `clickhouseClientVersion` out of `features/flows/clickhouse/pom.xml` and add `httpclient5Version` / `httpcore5Version` / `roaringbitmapVersion` / `jspecifyVersion`, so the module and the Karaf feature share one set of pins. Versions verified against `client-v2:0.8.6`'s `dependency:tree`.
2. **Add `opennms-clickhouse-client` Karaf feature**, mirroring `opennms-elastic-client`:
   - reuse existing features (`jackson-core`, `commons-codec`, `commons-io`, `commons-compress`) and already-OSGi bundles (`asm`, `at.yawk.lz4`);
   - `wrap:` the plain jars: HttpComponents 5.x (`httpcore5`, `httpcore5-h2`, `httpclient5`), RoaringBitmap + shims, jspecify, and `clickhouse-data` / `clickhouse-client` / `client-v2`. HttpComponents 5.x is disjoint from the 4.x used by the ES client.

## Validation
`container/features` filters and builds — all `${...}` versions in the new feature resolve (client-v2/0.8.6, httpclient5/5.3.1, …), 0 unresolved. Root-pom change trips a full CI build.

## Known limitations (by design)
- **Not smoke-exercised here:** nothing installs the feature yet, so the actual OSGi resolution — `wrap:` behaviour and any `DynamicImport-Package` tuning for ClickHouse's `ServiceLoader` compression/transport providers — is proven in **PR C**, which installs it into `opennms-flows` / `sentinel-flows`.
- **Version skew to watch in PR C:** `client-v2` pulls `commons-compress` 1.27.1 but the `commons-compress` feature pins 1.26.1; the wrapped import range likely tolerates it, else bump `commonsCompressVersion`.

## Next
PR C: atomic ES→ClickHouse swap in `opennms-flows` + `sentinel-flows` (install this feature + the clickhouse bundle, remove ES), delete `features/flows/elastic`, retire ES itests + ES flow e2e. Smoke-gated.

🤖 Generated with [Claude Code](https://claude.com/claude-code)