### PR TITLE
fix(flows): don't fail boot when ClickHouse is unreachable at startup

### DIFF
--- a/features/flows/clickhouse/src/main/java/org/opennms/netmgt/flows/clickhouse/ClickhouseSchemaBootstrap.java
+++ b/features/flows/clickhouse/src/main/java/org/opennms/netmgt/flows/clickhouse/ClickhouseSchemaBootstrap.java
@@ -41,6 +41,23 @@ public class ClickhouseSchemaBootstrap {
         this.ttlDays = ttlDays;
     }
 
+    /**
+     * Blueprint entry point: bootstrap the schema but never fail bundle startup. When ClickHouse is
+     * unreachable at boot (e.g. the smoke tests, or the server not yet up), this logs and returns so
+     * the flow services still register — matching the previous Elasticsearch repository's lazy
+     * behaviour. The ClickHouse health check reports the connectivity failure; persistence and queries
+     * will error until ClickHouse is reachable and OpenNMS is restarted so the schema can be applied.
+     */
+    public void initializeQuietly() {
+        try {
+            initialize();
+        } catch (final RuntimeException e) {
+            LOG.warn("ClickHouse flow schema bootstrap did not complete (is ClickHouse reachable at the "
+                    + "configured endpoint?). Flow persistence and queries will not work until ClickHouse "
+                    + "is available and OpenNMS is restarted.", e);
+        }
+    }
+
     public void initialize() {
         LOG.info("Initializing ClickHouse flow schema (ttlDays={}).", ttlDays);
         execute(LEDGER_DDL);

--- a/features/flows/clickhouse/src/main/resources/OSGI-INF/blueprint/blueprint.xml
+++ b/features/flows/clickhouse/src/main/resources/OSGI-INF/blueprint/blueprint.xml
@@ -60,7 +60,7 @@
     <bean id="clickhouseClient" factory-ref="clickhouseClientFactory" factory-method="createClient" destroy-method="close"/>
 
     <!-- Schema bootstrap (single source of truth for DDL; idempotent) -->
-    <bean id="clickhouseSchemaBootstrap" class="org.opennms.netmgt.flows.clickhouse.ClickhouseSchemaBootstrap" init-method="initialize">
+    <bean id="clickhouseSchemaBootstrap" class="org.opennms.netmgt.flows.clickhouse.ClickhouseSchemaBootstrap" init-method="initializeQuietly">
         <argument ref="clickhouseClient"/>
         <argument value="${ttlDays}"/>
     </bean>

--- a/features/flows/clickhouse/src/test/java/org/opennms/netmgt/flows/clickhouse/ClickhouseSchemaBootstrapTest.java
+++ b/features/flows/clickhouse/src/test/java/org/opennms/netmgt/flows/clickhouse/ClickhouseSchemaBootstrapTest.java
@@ -1,0 +1,35 @@
+/*
+ * SPDX-License-Identifier: AGPL-3.0-or-later
+ *
+ * Copyright 2026 The OpenNMS Group, Inc.
+ *
+ * Created by Ronny Trommer <ronny@opennms.com>
+ */
+package org.opennms.netmgt.flows.clickhouse;
+
+import static org.mockito.ArgumentMatchers.anyString;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
+
+import org.junit.Test;
+
+import com.clickhouse.client.api.Client;
+
+public class ClickhouseSchemaBootstrapTest {
+
+    /** initialize() fails fast so the ITs (and any strict caller) surface a real bootstrap problem. */
+    @Test(expected = IllegalStateException.class)
+    public void initializeThrowsWhenServerUnreachable() {
+        final Client client = mock(Client.class);
+        when(client.query(anyString())).thenThrow(new RuntimeException("connection refused"));
+        new ClickhouseSchemaBootstrap(client, 0).initialize();
+    }
+
+    /** initializeQuietly() (the blueprint entry point) must NOT fail bundle startup when ClickHouse is down. */
+    @Test
+    public void initializeQuietlyToleratesUnreachableServer() {
+        final Client client = mock(Client.class);
+        when(client.query(anyString())).thenThrow(new RuntimeException("connection refused"));
+        new ClickhouseSchemaBootstrap(client, 0).initializeQuietly(); // no exception = pass
+    }
+}


### PR DESCRIPTION
## What

Follow-up to the phase-6 cut-over (#179). The ClickHouse blueprint bootstraps the schema **eagerly** at bean init, and the flow repository / query-service beans `depends-on` it, feeding the **mandatory** `FlowQueryService` reference in `flows/rest`. So in any environment **without** a reachable ClickHouse — notably the **smoke tests** (which boot the OCI with no ClickHouse container) — the eager bootstrap threw after the 5s connect timeout, the dependent beans never registered, and the whole flows subsystem failed to come up.

The old Elasticsearch repository connected lazily, so boot succeeded without a backend. This restores that behaviour.

## How
- New `ClickhouseSchemaBootstrap.initializeQuietly()` — the blueprint's new `init-method` — runs the bootstrap but **logs-and-continues** on failure instead of throwing. Flow services register, the container boots, and the ClickHouse **health check** reports the connectivity failure. Persistence/queries error until ClickHouse is reachable and OpenNMS is restarted.
- `initialize()` stays **strict** (throws), so the ITs still fail fast on a real DDL regression.

## Tests
`ClickhouseSchemaBootstrapTest`: `initialize()` throws on an unreachable server, `initializeQuietly()` tolerates it. The clickhouse ITs still bootstrap a real ClickHouse via `initialize()`. **18 unit + 4 IT green.**

## Why it matters now
This is almost certainly what would (or did) turn `main` smoke red after #179 — the cut-over left flows unable to boot without a ClickHouse present. This unblocks it and makes the flows subsystem boot gracefully in any ClickHouse-less environment (smoke, fresh installs, DB not yet up).

🤖 Generated with [Claude Code](https://claude.com/claude-code)