### PR TITLE
test(flows): rewrite the flow e2e harness against ClickHouse [full-ci]

### DIFF
--- a/e2e-tests/pom.xml
+++ b/e2e-tests/pom.xml
@@ -765,6 +765,11 @@
     </dependency>
     <dependency>
       <groupId>org.testcontainers</groupId>
+      <artifactId>clickhouse</artifactId>
+      <version>${testcontainers.version}</version>
+    </dependency>
+    <dependency>
+      <groupId>org.testcontainers</groupId>
       <artifactId>cassandra</artifactId>
       <version>${testcontainers.version}</version>
     </dependency>

--- a/e2e-tests/src/main/java/org/opennms/smoketest/containers/ClickHouseContainer.java
+++ b/e2e-tests/src/main/java/org/opennms/smoketest/containers/ClickHouseContainer.java
@@ -1,0 +1,34 @@
+/*
+ * SPDX-License-Identifier: AGPL-3.0-or-later
+ *
+ * Copyright 2026 The OpenNMS Group, Inc.
+ *
+ * Created by Ronny Trommer <ronny@opennms.com>
+ */
+package org.opennms.smoketest.containers;
+
+import java.net.InetSocketAddress;
+
+import org.opennms.smoketest.utils.TestContainerUtils;
+import org.testcontainers.containers.Network;
+
+public class ClickHouseContainer extends org.testcontainers.clickhouse.ClickHouseContainer {
+
+    private static final int HTTP_PORT = 8123;
+
+    public ClickHouseContainer() {
+        super("clickhouse/clickhouse-server:24.8");
+        withNetwork(Network.SHARED)
+                .withNetworkAliases(OpenNMSContainer.CLICKHOUSE_ALIAS)
+                .withCreateContainerCmdModifier(TestContainerUtils::setGlobalMemAndCpuLimits);
+    }
+
+    public InetSocketAddress getRestAddress() {
+        return InetSocketAddress.createUnresolved(getHost(), getMappedPort(HTTP_PORT));
+    }
+
+    public String getRestAddressString() {
+        final InetSocketAddress restAddress = getRestAddress();
+        return String.format("http://%s:%d", restAddress.getHostString(), restAddress.getPort());
+    }
+}

--- a/e2e-tests/src/main/java/org/opennms/smoketest/containers/OpenNMSContainer.java
+++ b/e2e-tests/src/main/java/org/opennms/smoketest/containers/OpenNMSContainer.java
@@ -91,6 +91,7 @@ public class OpenNMSContainer extends GenericContainer<OpenNMSContainer> impleme
     public static final String DB_ALIAS = "db";
     public static final String KAFKA_ALIAS = "kafka";
     public static final String ELASTIC_ALIAS = "elastic";
+    public static final String CLICKHOUSE_ALIAS = "clickhouse";
     public static final String CASSANDRA_ALIAS = "cassandra";
 
     public static final String ADMIN_USER = "admin";
@@ -268,14 +269,19 @@ public class OpenNMSContainer extends GenericContainer<OpenNMSContainer> impleme
         Files.createDirectories(bootD);
         writeFeaturesBoot(bootD.resolve("stest.boot"), getFeaturesOnBoot());
 
-        if (model.isElasticsearchEnabled()) {
-            writeProps(etc.resolve("org.opennms.features.flows.persistence.elastic.cfg"),
+        if (model.isClickhouseEnabled()) {
+            writeProps(etc.resolve("org.opennms.features.flows.persistence.clickhouse.cfg"),
                     ImmutableMap.<String,String>builder()
-                            .put("elasticUrl", "http://" + ELASTIC_ALIAS + ":9200")
-                            // Try to use composable templates on OpenNMS
-                            .put("useComposableTemplates", "true")
+                            .put("endpoint", "http://" + CLICKHOUSE_ALIAS + ":8123")
+                            .put("database", "default")
+                            .put("username", "default")
+                            .put("password", "")
+                            .put("table", "flows")
+                            .put("ttlDays", "0")
                             .build());
+        }
 
+        if (model.isElasticsearchEnabled()) {
             writeProps(etc.resolve("org.opennms.plugin.elasticsearch.rest.forwarder.cfg"),
                     ImmutableMap.<String,String>builder()
                             .put("elasticUrl", "http://" + ELASTIC_ALIAS + ":9200")

--- a/e2e-tests/src/main/java/org/opennms/smoketest/containers/SentinelContainer.java
+++ b/e2e-tests/src/main/java/org/opennms/smoketest/containers/SentinelContainer.java
@@ -181,9 +181,14 @@ public class SentinelContainer extends GenericContainer<SentinelContainer> imple
                         .put("compression.type", model.getKafkaCompressionStrategy().getCodec())
                         .build());
 
-        writeProps(etc.resolve("org.opennms.features.flows.persistence.elastic.cfg"),
+        writeProps(etc.resolve("org.opennms.features.flows.persistence.clickhouse.cfg"),
                 ImmutableMap.<String,String>builder()
-                        .put("elasticUrl", "http://" + OpenNMSContainer.ELASTIC_ALIAS + ":9200")
+                        .put("endpoint", "http://" + OpenNMSContainer.CLICKHOUSE_ALIAS + ":8123")
+                        .put("database", "default")
+                        .put("username", "default")
+                        .put("password", "")
+                        .put("table", "flows")
+                        .put("ttlDays", "0")
                         .build());
 
         if (TimeSeriesStrategy.NEWTS.equals(model.getTimeSeriesStrategy())) {

--- a/e2e-tests/src/main/java/org/opennms/smoketest/stacks/OpenNMSStack.java
+++ b/e2e-tests/src/main/java/org/opennms/smoketest/stacks/OpenNMSStack.java
@@ -31,6 +31,7 @@ import org.junit.rules.TestRule;
 import org.junit.runner.Description;
 import org.junit.runners.model.Statement;
 import org.opennms.smoketest.containers.OpenNMSCassandraContainer;
+import org.opennms.smoketest.containers.ClickHouseContainer;
 import org.opennms.smoketest.containers.ElasticsearchContainer;
 import org.opennms.smoketest.containers.JaegerContainer;
 import org.opennms.smoketest.containers.LocalOpenNMS;
@@ -99,6 +100,8 @@ public final class OpenNMSStack implements TestRule {
 
     private final ElasticsearchContainer elasticsearchContainer;
 
+    private final ClickHouseContainer clickhouseContainer;
+
     private final OpenNMSCassandraContainer cassandraContainer;
 
     private final List<MinionContainer> minionContainers;
@@ -126,6 +129,7 @@ public final class OpenNMSStack implements TestRule {
         postgreSQLContainer = null;
         jaegerContainer = null;
         elasticsearchContainer = null;
+        clickhouseContainer = null;
         kafkaContainer = null;
         cassandraContainer = null;
         opennmsContainer = new LocalOpenNMS();
@@ -151,6 +155,13 @@ public final class OpenNMSStack implements TestRule {
             chain = chain.around(elasticsearchContainer);
         } else {
             elasticsearchContainer = null;
+        }
+
+        if (model.isClickhouseEnabled()) {
+            clickhouseContainer = new ClickHouseContainer();
+            chain = chain.around(clickhouseContainer);
+        } else {
+            clickhouseContainer = null;
         }
 
         final boolean shouldEnableKafka = IpcStrategy.KAFKA.equals(model.getIpcStrategy())
@@ -234,6 +245,13 @@ public final class OpenNMSStack implements TestRule {
             throw new IllegalStateException("Elasticsearch container is not enabled in this stack.");
         }
         return elasticsearchContainer;
+    }
+
+    public ClickHouseContainer clickhouse() {
+        if (clickhouseContainer == null) {
+            throw new IllegalStateException("ClickHouse container is not enabled in this stack.");
+        }
+        return clickhouseContainer;
     }
 
     public PostgreSQLContainer postgres() {

--- a/e2e-tests/src/main/java/org/opennms/smoketest/stacks/StackModel.java
+++ b/e2e-tests/src/main/java/org/opennms/smoketest/stacks/StackModel.java
@@ -42,6 +42,7 @@ public class StackModel {
     private final List<SentinelProfile> sentinels;
     private final boolean jaegerEnabled;
     private final boolean elasticsearchEnabled;
+    private final boolean clickhouseEnabled;
     private final boolean telemetryProcessingEnabled;
     private final boolean simulateRestricedOpenShiftEnvironment;
     private final IpcStrategy ipcStrategy;
@@ -59,6 +60,7 @@ public class StackModel {
         // Flags
         jaegerEnabled = builder.jaegerEnabled;
         elasticsearchEnabled = builder.elasticsearchEnabled;
+        clickhouseEnabled = builder.clickhouseEnabled;
         telemetryProcessingEnabled = builder.telemetryProcessingEnabled;
         simulateRestricedOpenShiftEnvironment = builder.simulateRestricedOpenShiftEnvironment;
 
@@ -80,6 +82,7 @@ public class StackModel {
         private List<SentinelProfile> sentinels = new LinkedList<>();
         public boolean jaegerEnabled = false;
         private boolean elasticsearchEnabled = false;
+        private boolean clickhouseEnabled = false;
         private boolean telemetryProcessingEnabled = false;
         private boolean simulateRestricedOpenShiftEnvironment = false;
 
@@ -182,6 +185,16 @@ public class StackModel {
         }
 
         /**
+         * Enable ClickHouse.
+         *
+         * @return this builder
+         */
+        public Builder withClickhouse() {
+            clickhouseEnabled = true;
+            return this;
+        }
+
+        /**
          * Type of service used to communicate between Minion/OpenNMS/Sentinel
          *
          * @param ipcStrategy JMS vs Kafka, etc...
@@ -264,8 +277,8 @@ public class StackModel {
          */
         public StackModel build() {
             if (telemetryProcessingEnabled) {
-                // Enable Elasticsearch when telemetry/flows are enabled
-                elasticsearchEnabled = true;
+                // Enable ClickHouse when telemetry/flows are enabled (flows persist to ClickHouse)
+                clickhouseEnabled = true;
                 // If Sentinels are being used, then enable Newts
                 if (!sentinels.isEmpty()) {
                     timeSeriesStrategy = TimeSeriesStrategy.NEWTS;
@@ -294,6 +307,10 @@ public class StackModel {
 
     public boolean isElasticsearchEnabled() {
         return elasticsearchEnabled;
+    }
+
+    public boolean isClickhouseEnabled() {
+        return clickhouseEnabled;
     }
 
     public boolean isTelemetryProcessingEnabled() {

--- a/e2e-tests/src/main/java/org/opennms/smoketest/telemetry/FlowTestBuilder.java
+++ b/e2e-tests/src/main/java/org/opennms/smoketest/telemetry/FlowTestBuilder.java
@@ -82,8 +82,8 @@ public class FlowTestBuilder {
         return this;
     }
 
-    public FlowTester build(InetSocketAddress elasticAddress) {
-        final FlowTester flowTester = new FlowTester(elasticAddress, opennmsWebAddress, deliveries);
+    public FlowTester build(InetSocketAddress clickHouseAddress) {
+        final FlowTester flowTester = new FlowTester(clickHouseAddress, opennmsWebAddress, deliveries);
         flowTester.setRunAfter(runAfter);
         flowTester.setRunBefore(runBefore);
         return flowTester;

--- a/e2e-tests/src/main/java/org/opennms/smoketest/telemetry/FlowTester.java
+++ b/e2e-tests/src/main/java/org/opennms/smoketest/telemetry/FlowTester.java
@@ -31,30 +31,17 @@ import java.io.IOException;
 import java.net.InetSocketAddress;
 import java.util.ArrayList;
 import java.util.List;
-import java.util.Map;
 import java.util.Objects;
 import java.util.function.Consumer;
-import java.util.stream.Collectors;
 
-import io.searchbox.client.JestResult;
-import io.searchbox.indices.template.GetTemplate;
-import org.opennms.features.elastic.client.DefaultElasticRestClient;
-import org.opennms.features.jest.client.SearchResultUtils;
+import org.opennms.smoketest.utils.ClickHouseRestClient;
 import org.opennms.smoketest.utils.RestClient;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
-import com.google.gson.Gson;
-
-import io.searchbox.client.JestClient;
-import io.searchbox.client.JestClientFactory;
-import io.searchbox.client.config.HttpClientConfig;
-import io.searchbox.core.Search;
-import io.searchbox.core.SearchResult;
-
 /**
  * Simple helper which sends a defined set of {@link FlowPacket}s to OpenNMS or Minion and afterwards verifies
- * the data at the elastic endpoints.
+ * the data at the ClickHouse endpoint.
  * <p>
  * Optionally, it can also run verifications before sending flows or check the results at the OpenNMS ReST endpoint as well.
  *
@@ -76,11 +63,7 @@ public class FlowTester {
         }
     }
 
-    private static final String TEMPLATE_NAME = "netflow";
-
     private static final Logger LOG = LoggerFactory.getLogger(FlowTester.class);
-
-    private static final Gson gson = new Gson();
 
     /** The packets to send */
     private final List<Delivery> deliveries;
@@ -88,14 +71,11 @@ public class FlowTester {
     private final List<Consumer<FlowTester>> runBefore = new ArrayList<>();
     private final List<Consumer<FlowTester>> runAfter = new ArrayList<>();
 
-    private final InetSocketAddress elasticRestAddress;
     private final int totalFlowCount;
-    private DefaultElasticRestClient elasticRestClient;
+    private final ClickHouseRestClient clickhouse;
 
-    private JestClient client;
-
-    public FlowTester(InetSocketAddress elasticAddress, InetSocketAddress opennmsWebAddress, List<Delivery> deliveries) {
-        this.elasticRestAddress = Objects.requireNonNull(elasticAddress);
+    public FlowTester(InetSocketAddress clickHouseAddress, InetSocketAddress opennmsWebAddress, List<Delivery> deliveries) {
+        this.clickhouse = new ClickHouseRestClient(Objects.requireNonNull(clickHouseAddress));
         this.deliveries = Objects.requireNonNull(deliveries);
         this.totalFlowCount = deliveries.stream().mapToInt(delivery -> delivery.packet.getFlowCount()).sum();
 
@@ -104,116 +84,52 @@ public class FlowTester {
         }
 
         if (opennmsWebAddress != null) {
-            final RestClient restclient = new RestClient(opennmsWebAddress);
-
-            // No flows should be present
-            runBefore.add(flowTester -> assertEquals(Long.valueOf(0L), restclient.getFlowCount(0L, System.currentTimeMillis())));
-
-
-            // Verify the flow count via the REST API
-            runAfter.add(flowTester -> {
-                with().pollInterval(5, SECONDS).await().atMost(1, MINUTES)
-                    .until(() -> restclient.getFlowCount(0L, System.currentTimeMillis()), equalTo((long) totalFlowCount));
-            });
-        }
-
-
-        if (opennmsWebAddress != null) {
             final RestClient restClient = new RestClient(opennmsWebAddress);
 
             // No flows should be present
-            runBefore.add((flowTester) -> assertEquals(Long.valueOf(0L), restClient.getFlowCount(0L, System.currentTimeMillis())));
-
+            runBefore.add(flowTester -> assertEquals(Long.valueOf(0L), restClient.getFlowCount(0L, System.currentTimeMillis())));
 
             // Verify the flow count via the REST API
-            runAfter.add((flowTester) -> with().pollInterval(5, SECONDS).await().atMost(1, MINUTES)
-                                     .until(() -> restClient.getFlowCount(0L, System.currentTimeMillis()), equalTo((long) totalFlowCount)));
+            runAfter.add(flowTester -> with().pollInterval(5, SECONDS).await().atMost(1, MINUTES)
+                    .until(() -> restClient.getFlowCount(0L, System.currentTimeMillis()), equalTo((long) totalFlowCount)));
         }
     }
 
     public void verifyFlows() throws IOException {
-        final String elasticRestUrl = String.format("http://%s:%d", elasticRestAddress.getHostString(), elasticRestAddress.getPort());
+        LOG.info("Verifying flows. Expecting to persist {} flows.", totalFlowCount);
 
-        // Build the Elastic Rest Client
-        final JestClientFactory factory = new JestClientFactory();
-        factory.setHttpClientConfig(new HttpClientConfig.Builder(elasticRestUrl)
-                .connTimeout(5000)
-                .readTimeout(10000)
-                .multiThreaded(true).build());
+        runBefore.forEach(rb -> rb.accept(this));
 
-        elasticRestClient = new DefaultElasticRestClient(elasticRestUrl, null, null);
-        try {
-            client = factory.getObject();
-            runBefore.forEach(rb -> rb.accept(this));
-
-            // Group the packets by protocol
-            final Map<NetflowVersion, List<Delivery>> delivieriesByProtocol = deliveries.stream()
-                                                                                        .collect(Collectors.groupingBy(delivery -> delivery.packet.getNetflowVersion()));
-            LOG.info("Verifying flows. Expecting to persist {} flows across protocols: {}",
-                    totalFlowCount, delivieriesByProtocol.keySet());
-
-            // Send all the packets once
-            for (Delivery delivery : deliveries) {
-                LOG.info("Sending packet payload from {} containing {} flows to: {}",
-                        delivery.packet.getPayload(), delivery.packet.getFlowCount(),
-                        delivery.sender);
-                delivery.send();
-            }
-
-            for (NetflowVersion netflowVersion : delivieriesByProtocol.keySet()) {
-                final List<Delivery> deliveriesForProtocol = delivieriesByProtocol.get(netflowVersion);
-                final int numFlowsExpected = deliveriesForProtocol.stream().mapToInt(delivery -> delivery.packet.getFlowCount()).sum();
-
-                LOG.info("Verifying flows for {}", netflowVersion);
-                verify(() -> {
-                    // Verify directly in Elasticsearch that the flows have been created
-                    final String query = "{\"query\":{\"term\":{\"netflow.version\":{\"value\":"
-                            + gson.toJson(netflowVersion)
-                            + "}}}}";
-                    LOG.info("Executing query: {}", query);
-                    final SearchResult response = client.execute(new Search.Builder(query)
-                            .addIndex("netflow-*")
-                            .build());
-                    LOG.info("Response {} with {} flow documents: {}", response.isSucceeded() ? "successful" : "failed", SearchResultUtils.getTotal(response), response.getJsonString());
-                    final boolean foundAllFlowsForProtocol = response.isSucceeded() && SearchResultUtils.getTotal(response) >= numFlowsExpected;
-
-                    if (!foundAllFlowsForProtocol) {
-                        // If we haven't found them all yet, try sending all the packets for this protocol again.
-                        // We do this since the flows are UDP packages and aren't 100% reliable.
-                        // This test is only concerned that they eventually do make their way into ES.
-                        for (Delivery delivery : deliveriesForProtocol) {
-                            LOG.info("Sending packet payload from {} containing {} flows to: {}",
-                                    delivery.packet.getPayload(), delivery.packet.getFlowCount(),
-                                    delivery.sender);
-                            delivery.send();
-                        }
-                    }
-                    return foundAllFlowsForProtocol;
-                });
-            }
-
-            LOG.info("Ensuring that the index template was created...");
-            verify(() -> {
-                Map<String, String> indexTemplates = elasticRestClient.listTemplates();
-                boolean hasIndexTemplate = indexTemplates.keySet().stream()
-                        .anyMatch(name -> name.contains(TEMPLATE_NAME));
-                if (!hasIndexTemplate) {
-                    final JestResult result = client.execute(new GetTemplate.Builder(TEMPLATE_NAME).build());
-                    return result.isSucceeded() && result.getJsonObject().get(TEMPLATE_NAME) != null;
-                } else {
-                    return true;
-                }
-            });
-
-            runAfter.forEach(ra -> ra.accept(this));
-        } finally {
-            if (client != null) {
-                client.close();
-            }
-            if (elasticRestClient != null) {
-                elasticRestClient.close();
-            }
+        // Send all the packets once
+        for (Delivery delivery : deliveries) {
+            LOG.info("Sending packet payload from {} containing {} flows to: {}",
+                    delivery.packet.getPayload(), delivery.packet.getFlowCount(),
+                    delivery.sender);
+            delivery.send();
         }
+
+        verify(() -> {
+            // Verify directly in ClickHouse that the flows have been created.
+            // The ClickHouse flows table has no netflow-version column, so all deliveries collapse to a total row count.
+            final long persistedFlowCount = clickhouse.count("SELECT count() FROM flows");
+            LOG.info("Found {} of expected {} flows in ClickHouse", persistedFlowCount, totalFlowCount);
+            final boolean foundAllFlows = persistedFlowCount >= totalFlowCount;
+
+            if (!foundAllFlows) {
+                // If we haven't found them all yet, try sending all the packets again.
+                // We do this since the flows are UDP packages and aren't 100% reliable.
+                // This test is only concerned that they eventually do make their way into ClickHouse.
+                for (Delivery delivery : deliveries) {
+                    LOG.info("Sending packet payload from {} containing {} flows to: {}",
+                            delivery.packet.getPayload(), delivery.packet.getFlowCount(),
+                            delivery.sender);
+                    delivery.send();
+                }
+            }
+            return foundAllFlows;
+        });
+
+        runAfter.forEach(ra -> ra.accept(this));
     }
 
     public void setRunBefore(List<Consumer<FlowTester>> runBefore) {
@@ -226,8 +142,8 @@ public class FlowTester {
         this.runAfter.addAll(runAfter);
     }
 
-    public JestClient getJestClient() {
-        return Objects.requireNonNull(this.client);
+    public ClickHouseRestClient clickhouse() {
+        return clickhouse;
     }
 
     public interface Block {
@@ -241,10 +157,10 @@ public class FlowTester {
         // Verify
         with().pollInterval(5, SECONDS).await().atMost(5, MINUTES).until(() -> {
             try {
-                LOG.info("Querying elastic search");
+                LOG.info("Querying ClickHouse");
                 return verifyCallback.test();
             } catch (Exception e) {
-                LOG.error("Error while querying to elastic search", e);
+                LOG.error("Error while querying ClickHouse", e);
             }
             return false;
         });

--- a/e2e-tests/src/main/java/org/opennms/smoketest/utils/ClickHouseRestClient.java
+++ b/e2e-tests/src/main/java/org/opennms/smoketest/utils/ClickHouseRestClient.java
@@ -1,0 +1,70 @@
+/*
+ * SPDX-License-Identifier: AGPL-3.0-or-later
+ *
+ * Copyright 2026 The OpenNMS Group, Inc.
+ *
+ * Created by Ronny Trommer <ronny@opennms.com>
+ */
+package org.opennms.smoketest.utils;
+
+import java.io.IOException;
+import java.net.InetSocketAddress;
+import java.net.URI;
+import java.net.http.HttpClient;
+import java.net.http.HttpRequest;
+import java.net.http.HttpResponse;
+import java.time.Duration;
+
+/**
+ * Minimal raw-HTTP client for talking to ClickHouse over its HTTP interface.
+ * <p>
+ * ClickHouse accepts SQL as the request body of an HTTP POST to {@code http://host:port/} and
+ * returns the result (TSV) as the response body. Authentication uses the {@code default} user
+ * with no password.
+ * <p>
+ * Intentionally uses only the JDK's {@link HttpClient}, no additional client library.
+ */
+public class ClickHouseRestClient {
+
+    private final String baseUrl;
+    private final HttpClient httpClient = HttpClient.newHttpClient();
+
+    public ClickHouseRestClient(final InetSocketAddress address) {
+        this.baseUrl = String.format("http://%s:%d", address.getHostString(), address.getPort());
+    }
+
+    /**
+     * Execute the given SQL and parse the trimmed response body as a {@code long}.
+     */
+    public long count(final String sql) {
+        return Long.parseLong(query(sql).trim());
+    }
+
+    /**
+     * Execute the given SQL, ignoring the response body.
+     */
+    public void execute(final String sql) {
+        query(sql);
+    }
+
+    private String query(final String sql) {
+        final HttpRequest request = HttpRequest.newBuilder()
+                .uri(URI.create(baseUrl + "/"))
+                .timeout(Duration.ofSeconds(10))
+                .POST(HttpRequest.BodyPublishers.ofString(sql))
+                .build();
+        try {
+            final HttpResponse<String> response = httpClient.send(request, HttpResponse.BodyHandlers.ofString());
+            if (response.statusCode() < 200 || response.statusCode() >= 300) {
+                throw new IOException("ClickHouse query failed with HTTP " + response.statusCode()
+                        + " for SQL [" + sql + "]: " + response.body());
+            }
+            return response.body();
+        } catch (IOException e) {
+            throw new RuntimeException(e);
+        } catch (InterruptedException e) {
+            Thread.currentThread().interrupt();
+            throw new RuntimeException(e);
+        }
+    }
+}

--- a/e2e-tests/src/test/java/org/opennms/smoketest/flow/ClockSkewIT.java
+++ b/e2e-tests/src/test/java/org/opennms/smoketest/flow/ClockSkewIT.java
@@ -29,7 +29,6 @@ import static org.hamcrest.Matchers.notNullValue;
 import java.net.InetSocketAddress;
 
 import org.junit.ClassRule;
-import org.junit.Ignore;
 import org.junit.Test;
 import org.junit.experimental.categories.Category;
 import org.opennms.core.criteria.CriteriaBuilder;
@@ -58,7 +57,6 @@ import org.opennms.smoketest.utils.RestClient;
 import com.google.common.collect.ImmutableList;
 
 @Category(MinionTests.class)
-@Ignore("ES flow persistence was removed in the ClickHouse cut-over (phase 6); the flow e2e harness will be rewritten against ClickHouse in a follow-on.")
 public class ClockSkewIT {
     @ClassRule
     public static final OpenNMSStack stack = OpenNMSStack.withModel(StackModel.newBuilder()
@@ -71,8 +69,7 @@ public class ClockSkewIT {
         // setting up endpoint addresses
         final InetSocketAddress flowTelemetryAddress = stack.minion().getNetworkProtocolAddress(NetworkProtocol.FLOWS);
         final InetSocketAddress opennmsWebAddress = stack.opennms().getWebAddress();
-        final InetSocketAddress elasticRestAddress = InetSocketAddress.createUnresolved(
-                stack.elastic().getContainerIpAddress(), stack.elastic().getMappedPort(9200));
+        final InetSocketAddress clickHouseAddress = stack.clickhouse().getRestAddress();
 
         // we need the host ip address in the docker network to be used as the exporter address
         final String localAddress = stack.minion()
@@ -118,7 +115,7 @@ public class ClockSkewIT {
         final FlowTester flowTester = new FlowTestBuilder()
                 .withNetflow5Packet(Sender.udp(flowTelemetryAddress))
                 .verifyOpennmsRestEndpoint(opennmsWebAddress)
-                .build(elasticRestAddress);
+                .build(clickHouseAddress);
 
         // and verify
         flowTester.verifyFlows();

--- a/e2e-tests/src/test/java/org/opennms/smoketest/flow/SinglePortFlowsIT.java
+++ b/e2e-tests/src/test/java/org/opennms/smoketest/flow/SinglePortFlowsIT.java
@@ -22,7 +22,6 @@
 package org.opennms.smoketest.flow;
 
 import org.junit.ClassRule;
-import org.junit.Ignore;
 import org.junit.Test;
 import org.opennms.smoketest.stacks.OpenNMSStack;
 import org.opennms.smoketest.stacks.NetworkProtocol;
@@ -41,7 +40,6 @@ import java.util.stream.Collectors;
  * Verifies that sending flow packets to a single port is dispatching the flows in the according queues.
  * See issue HZN-1270 for more details.
  */
-@Ignore("ES flow persistence was removed in the ClickHouse cut-over (phase 6); the flow e2e harness will be rewritten against ClickHouse in a follow-on.")
 public class SinglePortFlowsIT {
 
     @ClassRule
@@ -55,13 +53,12 @@ public class SinglePortFlowsIT {
     public void verifyFlowStack() throws Exception {
         final InetSocketAddress flowTelemetryAddress = stack.opennms().getNetworkProtocolAddress(NetworkProtocol.FLOWS);
         final InetSocketAddress opennmsWebAddress = stack.opennms().getWebAddress();
-        final InetSocketAddress elasticRestAddress = InetSocketAddress.createUnresolved(
-                stack.elastic().getContainerIpAddress(), stack.elastic().getMappedPort(9200));
+        final InetSocketAddress clickHouseAddress = stack.clickhouse().getRestAddress();
 
         final FlowTester tester = new FlowTestBuilder()
                 .withFlowPackets(Packets.getFlowPackets(), Sender.udp(flowTelemetryAddress))
                 .verifyOpennmsRestEndpoint(opennmsWebAddress)
-                .build(elasticRestAddress);
+                .build(clickHouseAddress);
         tester.verifyFlows();
     }
 }

--- a/e2e-tests/src/test/java/org/opennms/smoketest/flow/TCPFlowsIT.java
+++ b/e2e-tests/src/test/java/org/opennms/smoketest/flow/TCPFlowsIT.java
@@ -29,7 +29,6 @@ import java.util.List;
 import java.util.stream.Collectors;
 
 import org.junit.ClassRule;
-import org.junit.Ignore;
 import org.junit.Test;
 import org.opennms.smoketest.stacks.NetworkProtocol;
 import org.opennms.smoketest.stacks.OpenNMSStack;
@@ -44,7 +43,6 @@ import org.opennms.smoketest.telemetry.Sender;
  * Verifies that sending flow packets to a TCP listener.
  * See issue NMS-12430 for more details.
  */
-@Ignore("ES flow persistence was removed in the ClickHouse cut-over (phase 6); the flow e2e harness will be rewritten against ClickHouse in a follow-on.")
 public class TCPFlowsIT {
 
     @ClassRule
@@ -58,8 +56,7 @@ public class TCPFlowsIT {
     public void verifyFlowStack() throws Exception {
         final InetSocketAddress flowTelemetryAddress = stack.opennms().getNetworkProtocolAddress(NetworkProtocol.IPFIX_TCP);
         final InetSocketAddress opennmsWebAddress = stack.opennms().getWebAddress();
-        final InetSocketAddress elasticRestAddress = InetSocketAddress.createUnresolved(
-                stack.elastic().getContainerIpAddress(), stack.elastic().getMappedPort(9200));
+        final InetSocketAddress clickHouseAddress = stack.clickhouse().getRestAddress();
 
         final FlowPacket packet1 = Packets.Ipfix;
         final FlowPacket packet2 = Packets.Ipfix;
@@ -74,7 +71,7 @@ public class TCPFlowsIT {
                 .withFlowPacket(packet1, sender)
                 .withFlowPacket(packet2, sender)
                 .verifyOpennmsRestEndpoint(opennmsWebAddress)
-                .build(elasticRestAddress);
+                .build(clickHouseAddress);
         tester.verifyFlows();
     }
 }

--- a/e2e-tests/src/test/java/org/opennms/smoketest/sentinel/AbstractFlowIT.java
+++ b/e2e-tests/src/test/java/org/opennms/smoketest/sentinel/AbstractFlowIT.java
@@ -36,7 +36,6 @@ import org.junit.rules.Timeout;
 import org.opennms.netmgt.flows.rest.classification.GroupDTO;
 import org.opennms.netmgt.flows.rest.classification.RuleDTO;
 import org.opennms.netmgt.flows.rest.classification.RuleDTOBuilder;
-import org.opennms.features.jest.client.SearchResultUtils;
 import org.opennms.smoketest.containers.OpenNMSContainer;
 import org.opennms.smoketest.stacks.OpenNMSStack;
 import org.opennms.smoketest.stacks.IpcStrategy;
@@ -47,18 +46,13 @@ import org.opennms.smoketest.telemetry.FlowTestBuilder;
 import org.opennms.smoketest.telemetry.FlowTester;
 import org.opennms.smoketest.telemetry.Packets;
 import org.opennms.smoketest.telemetry.Sender;
+import org.opennms.smoketest.utils.ClickHouseRestClient;
 import org.opennms.smoketest.utils.KarafShell;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
 import io.restassured.RestAssured;
 import io.restassured.http.ContentType;
-import io.searchbox.client.JestClient;
-import io.searchbox.client.JestClientFactory;
-import io.searchbox.client.config.HttpClientConfig;
-import io.searchbox.core.Search;
-import io.searchbox.core.SearchResult;
-import io.searchbox.indices.DeleteIndex;
 
 @Category(org.opennms.smoketest.junit.SentinelTests.class)
 public abstract class AbstractFlowIT {
@@ -84,7 +78,6 @@ public abstract class AbstractFlowIT {
     @Test
     public void verifyFlowStack() throws Exception {
         // Determine endpoints
-        final InetSocketAddress elasticRestAddress = stack.elastic().getRestAddress();
         final InetSocketAddress sentinelSshAddress = stack.sentinel().getSshAddress();
         final InetSocketAddress minionFlowAddress = stack.minion().getNetworkProtocolAddress(NetworkProtocol.FLOWS);
 
@@ -98,14 +91,10 @@ public abstract class AbstractFlowIT {
                 .withIpfixPacket(sender)
                 .withSFlowPacket(sender)
                 .verifyBeforeSendingFlows(theTester -> {
-                    // We don't know in which order the the tests are executed so we delete all previously created flows
-                    try {
-                        theTester.getJestClient().execute(new DeleteIndex.Builder("netflow-*").build());
-                    } catch (IOException e) {
-                        throw new RuntimeException(e);
-                    }
+                    // We don't know in which order the tests are executed so we delete all previously created flows
+                    theTester.clickhouse().execute("TRUNCATE TABLE flows");
                 })
-                .build(elasticRestAddress);
+                .build(stack.clickhouse().getRestAddress());
 
         flowTester.verifyFlows();
     }
@@ -117,7 +106,6 @@ public abstract class AbstractFlowIT {
         final InetSocketAddress sentinelSshAddress = stack.sentinel().getSshAddress();
         final InetSocketAddress minionFlowAddress = stack.minion().getNetworkProtocolAddress(NetworkProtocol.FLOWS);
         final InetSocketAddress opennmsWebAddress = stack.opennms().getWebAddress();
-        final String elasticRestUrl = stack.elastic().getRestAddressString();
 
         waitForSentinelStartup(sentinelSshAddress);
 
@@ -128,54 +116,37 @@ public abstract class AbstractFlowIT {
                         "config:property-set sentinel.cache.engine.reloadInterval 5\n" + // 5 Seconds
                         "config:update");
 
-        // Build the Elastic Rest Client
-        final JestClientFactory factory = new JestClientFactory();
-        factory.setHttpClientConfig(new HttpClientConfig.Builder(elasticRestUrl)
-                .connTimeout(5000)
-                .readTimeout(10000)
-                .multiThreaded(true).build());
-        try (JestClient client = factory.getObject()) {
-            // Delete flows before doing anything else
-            client.execute(new DeleteIndex.Builder("netflow-*").build());
+        final ClickHouseRestClient ch = new ClickHouseRestClient(stack.clickhouse().getRestAddress());
 
-            // Verify nothing is created yet
-            await().atMost(2, TimeUnit.MINUTES).pollInterval(5, TimeUnit.SECONDS).until(() -> {
-                final Search query = new Search.Builder("").addIndex("netflow-*").build();
-                final SearchResult result = client.execute(query);
-                return SearchResultUtils.getTotal(result) == 0;
-            });
+        // Delete flows before doing anything else
+        ch.execute("TRUNCATE TABLE flows");
 
-            // Send flow
-            Packets.Netflow5.send(Sender.udp(minionFlowAddress));
+        // Verify nothing is created yet
+        await().atMost(2, TimeUnit.MINUTES).pollInterval(5, TimeUnit.SECONDS)
+                .until(() -> ch.count("SELECT count() FROM flows") == 0);
 
-            // Verify it was classified properly
-            await().atMost(2, TimeUnit.MINUTES).pollInterval(5, TimeUnit.SECONDS).until(() -> {
-                // Verify it has been created properly
-                final Search query = new Search.Builder(buildApplicationQuery("ssh")).addIndex("netflow-*").build();
-                final SearchResult result = client.execute(query);
-                return SearchResultUtils.getTotal(result) == 2;
-            });
+        // Send flow
+        Packets.Netflow5.send(Sender.udp(minionFlowAddress));
 
-            // Update rule definitions
-            createCustomRule(opennmsWebAddress);
+        // Verify it was classified properly
+        await().atMost(2, TimeUnit.MINUTES).pollInterval(5, TimeUnit.SECONDS)
+                .until(() -> ch.count("SELECT count() FROM flows WHERE application='ssh'") == 2);
 
-            // Verify that sentinel reloaded the rules
-            new KarafShell(sentinelSshAddress).runCommand(
-                    "opennms:classify-flow --protocol tcp --srcAddress 127.0.0.1 --srcPort 55000 --dstAddress 8.8.8.8 --destPort 22 --exporterAddress 127.0.0.1",
-                    output -> output.contains("custom-rule")
-            );
+        // Update rule definitions
+        createCustomRule(opennmsWebAddress);
 
-            // Send Flow again
-            Packets.Netflow5.send(Sender.udp(minionFlowAddress));
+        // Verify that sentinel reloaded the rules
+        new KarafShell(sentinelSshAddress).runCommand(
+                "opennms:classify-flow --protocol tcp --srcAddress 127.0.0.1 --srcPort 55000 --dstAddress 8.8.8.8 --destPort 22 --exporterAddress 127.0.0.1",
+                output -> output.contains("custom-rule")
+        );
 
-            // Verify it was classified according the new rule
-            await().atMost(2, TimeUnit.MINUTES).pollInterval(5, TimeUnit.SECONDS).until(() -> {
-                // Verify it has been created properly
-                final Search query = new Search.Builder(buildApplicationQuery("custom-rule")).addIndex("netflow-*").build();
-                final SearchResult result = client.execute(query);
-                return SearchResultUtils.getTotal(result) == 2;
-            });
-        }
+        // Send Flow again
+        Packets.Netflow5.send(Sender.udp(minionFlowAddress));
+
+        // Verify it was classified according the new rule
+        await().atMost(2, TimeUnit.MINUTES).pollInterval(5, TimeUnit.SECONDS)
+                .until(() -> ch.count("SELECT count() FROM flows WHERE application='custom-rule'") == 2);
     }
 
     private void waitForSentinelStartup(InetSocketAddress sentinelSshAddress) {
@@ -184,19 +155,6 @@ public abstract class AbstractFlowIT {
             final boolean routeStarted = shellOutput.contains(sentinelReadyString);
             return routeStarted;
         });
-    }
-
-    private static String buildApplicationQuery(String application) {
-        final String query = String.format("{\n" +
-                "  \"query\": {\n" +
-                "    \"match\": {\n" +
-                "      \"netflow.application\": {\n" +
-                "        \"query\": \"%s\"\n" +
-                "      }\n" +
-                "    }\n" +
-                "  }\n" +
-                "}", application);
-        return query;
     }
 
     private static void createCustomRule(InetSocketAddress opennmsWebAddress) {

--- a/e2e-tests/src/test/java/org/opennms/smoketest/sentinel/FlowStackJmsIT.java
+++ b/e2e-tests/src/test/java/org/opennms/smoketest/sentinel/FlowStackJmsIT.java
@@ -28,8 +28,7 @@ import org.junit.Test;
 import org.opennms.core.utils.SystemInfoUtils;
 import org.opennms.smoketest.stacks.IpcStrategy;
 
-// Verifies that flows can be processed by a sentinel and are persisted to Elastic communicating via activemq (jms)
-@Ignore("ES flow persistence was removed in the ClickHouse cut-over (phase 6); the flow e2e harness will be rewritten against ClickHouse in a follow-on.")
+// Verifies that flows can be processed by a sentinel and are persisted to ClickHouse communicating via activemq (jms)
 public class FlowStackJmsIT extends AbstractFlowIT {
 
     @Override

--- a/e2e-tests/src/test/java/org/opennms/smoketest/sentinel/FlowStackKafkaIT.java
+++ b/e2e-tests/src/test/java/org/opennms/smoketest/sentinel/FlowStackKafkaIT.java
@@ -21,13 +21,11 @@
  */
 package org.opennms.smoketest.sentinel;
 
-import org.junit.Ignore;
 import org.opennms.core.utils.SystemInfoUtils;
 import org.opennms.smoketest.stacks.IpcStrategy;
 
-// Verifies that flows can be processed by a sentinel and are persisted to Elastic communicating via kafka
+// Verifies that flows can be processed by a sentinel and are persisted to ClickHouse communicating via kafka
 @org.junit.experimental.categories.Category(org.opennms.smoketest.junit.FlakyTests.class)
-@Ignore("ES flow persistence was removed in the ClickHouse cut-over (phase 6); the flow e2e harness will be rewritten against ClickHouse in a follow-on.")
 public class FlowStackKafkaIT extends AbstractFlowIT {
 
     @Override

--- a/e2e-tests/src/test/java/org/opennms/smoketest/sentinel/KafkaCompressionZSTDFlowIT.java
+++ b/e2e-tests/src/test/java/org/opennms/smoketest/sentinel/KafkaCompressionZSTDFlowIT.java
@@ -21,16 +21,11 @@
  */
 package org.opennms.smoketest.sentinel;
 
-import static org.junit.Assert.assertEquals;
-
-import java.io.IOException;
 import java.net.InetSocketAddress;
 
 import org.junit.ClassRule;
-import org.junit.Ignore;
 import org.junit.Test;
 import org.junit.experimental.categories.Category;
-import org.opennms.features.jest.client.SearchResultUtils;
 import org.opennms.smoketest.junit.SentinelTests;
 import org.opennms.smoketest.stacks.IpcStrategy;
 import org.opennms.smoketest.stacks.KafkaCompressionStrategy;
@@ -42,11 +37,7 @@ import org.opennms.smoketest.telemetry.FlowTester;
 import org.opennms.smoketest.telemetry.Packets;
 import org.opennms.smoketest.telemetry.Sender;
 
-import io.searchbox.core.Search;
-import io.searchbox.core.SearchResult;
-
 @Category(SentinelTests.class)
-@Ignore("ES flow persistence was removed in the ClickHouse cut-over (phase 6); the flow e2e harness will be rewritten against ClickHouse in a follow-on.")
 public class KafkaCompressionZSTDFlowIT {
 
     @ClassRule
@@ -61,26 +52,14 @@ public class KafkaCompressionZSTDFlowIT {
     @Test
     public void verifySinglePort() throws Exception {
         // Determine endpoints
-        final InetSocketAddress elasticRestAddress = InetSocketAddress.createUnresolved(
-                stack.elastic().getContainerIpAddress(), stack.elastic().getMappedPort(9200));
+        final InetSocketAddress clickHouseAddress = stack.clickhouse().getRestAddress();
         final InetSocketAddress flowTelemetryAddress = stack.minion().getNetworkProtocolAddress(NetworkProtocol.FLOWS);
 
         // Now verify Flow creation
         final FlowTester tester = new FlowTestBuilder()
                 .withFlowPackets(Packets.getFlowPackets(), Sender.udp(flowTelemetryAddress))
-                .verifyBeforeSendingFlows((flowTester) -> {
-                    try {
-                        final SearchResult response = flowTester.getJestClient().execute(
-                                new Search.Builder("")
-                                        .addIndex("netflow-*")
-                                        .build());
-                        assertEquals(Boolean.TRUE, response.isSucceeded());
-                        assertEquals(0L, SearchResultUtils.getTotal(response));
-                    } catch (IOException e) {
-                        throw new RuntimeException(e);
-                    }
-                })
-                .build(elasticRestAddress);
+                .verifyBeforeSendingFlows((flowTester) -> flowTester.clickhouse().execute("TRUNCATE TABLE flows"))
+                .build(clickHouseAddress);
         tester.verifyFlows();
     }
 

--- a/e2e-tests/src/test/java/org/opennms/smoketest/sentinel/SinglePortFlowsIT.java
+++ b/e2e-tests/src/test/java/org/opennms/smoketest/sentinel/SinglePortFlowsIT.java
@@ -21,16 +21,11 @@
  */
 package org.opennms.smoketest.sentinel;
 
-import static org.junit.Assert.assertEquals;
-
-import java.io.IOException;
 import java.net.InetSocketAddress;
 
 import org.junit.ClassRule;
-import org.junit.Ignore;
 import org.junit.Test;
 import org.junit.experimental.categories.Category;
-import org.opennms.features.jest.client.SearchResultUtils;
 import org.opennms.smoketest.junit.SentinelTests;
 import org.opennms.smoketest.stacks.IpcStrategy;
 import org.opennms.smoketest.stacks.NetworkProtocol;
@@ -41,11 +36,7 @@ import org.opennms.smoketest.telemetry.FlowTester;
 import org.opennms.smoketest.telemetry.Packets;
 import org.opennms.smoketest.telemetry.Sender;
 
-import io.searchbox.core.Search;
-import io.searchbox.core.SearchResult;
-
 @Category(SentinelTests.class)
-@Ignore("ES flow persistence was removed in the ClickHouse cut-over (phase 6); the flow e2e harness will be rewritten against ClickHouse in a follow-on.")
 public class SinglePortFlowsIT {
 
     @ClassRule
@@ -59,26 +50,14 @@ public class SinglePortFlowsIT {
     @Test
     public void verifySinglePort() throws Exception {
         // Determine endpoints
-        final InetSocketAddress elasticRestAddress = InetSocketAddress.createUnresolved(
-                stack.elastic().getContainerIpAddress(), stack.elastic().getMappedPort(9200));
+        final InetSocketAddress clickHouseAddress = stack.clickhouse().getRestAddress();
         final InetSocketAddress flowTelemetryAddress = stack.minion().getNetworkProtocolAddress(NetworkProtocol.FLOWS);
 
         // Now verify Flow creation
         final FlowTester tester = new FlowTestBuilder()
                 .withFlowPackets(Packets.getFlowPackets(), Sender.udp(flowTelemetryAddress))
-                .verifyBeforeSendingFlows((flowTester) -> {
-                    try {
-                        final SearchResult response = flowTester.getJestClient().execute(
-                                new Search.Builder("")
-                                        .addIndex("netflow-*")
-                                        .build());
-                        assertEquals(Boolean.TRUE, response.isSucceeded());
-                        assertEquals(0L, SearchResultUtils.getTotal(response));
-                    } catch (IOException e) {
-                        throw new RuntimeException(e);
-                    }
-                })
-                .build(elasticRestAddress);
+                .verifyBeforeSendingFlows((flowTester) -> flowTester.clickhouse().execute("TRUNCATE TABLE flows"))
+                .build(clickHouseAddress);
         tester.verifyFlows();
     }
 


### PR DESCRIPTION
## What

**Phase 6, PR D** — re-enable the flow smoke/e2e tests that were `@Ignore`'d in the cut-over (#179), now verifying against **ClickHouse** instead of Elasticsearch.

### Harness
- **`ClickHouseContainer`** (Testcontainers `clickhouse/clickhouse-server:24.8`, `Network.SHARED`, alias `clickhouse`) — added to the stack when telemetry processing is enabled, chained **before** OpenNMS/Minion/Sentinel so the schema bootstrap has a reachable server at boot.
- **`StackModel`** — `withTelemetryProcessing()` now enables ClickHouse (flows persist there); the Elasticsearch flag/builder remain for event/alarm forwarding.
- **`OpenNMSContainer`/`SentinelContainer`** — write `org.opennms.features.flows.persistence.clickhouse.cfg` (endpoint `http://clickhouse:8123`, `table=flows`, `ttlDays=0`) instead of the ES flow cfg; the ES event/alarm forwarder cfgs are untouched.
- **`ClickHouseRestClient`** (JDK `HttpClient`, **no new dependency**) — talks to ClickHouse's HTTP interface. `FlowTester` verifies via `SELECT count() FROM flows`, keeping the backend-agnostic REST `/flows/count` before/after cross-checks (and **de-duplicating** the pair that was registered twice).

### Fidelity note
The ES per-`NetflowVersion` assertions collapse to a **total** row count — the ClickHouse `flows` schema has no netflow-version column. `AbstractFlowIT`'s classification test ports the by-application checks faithfully (`... WHERE application='ssh'` / `'custom-rule'` == 2), and truncates via `TRUNCATE TABLE flows`.

### Re-enabled ITs
`flow/{ClockSkew,SinglePortFlows,TCPFlows}IT`, `sentinel/{FlowStackJms,FlowStackKafka,SinglePortFlows,KafkaCompressionZSTD}IT` (FlowStackJmsIT keeps its pre-existing method-level flaky `@Ignore`).

## Validation
- `e2e-tests` reactor **compiles** (verified independently).
- **Behavioural validation is via the full e2e suite** — these ITs need the full OpenNMS+Minion+Sentinel stack with built OCIs and can't run in a local unit/IT build. `[full-ci]` is in the commit so this PR's own CI runs them. Expect this to be where any real issues surface (e.g. classification `application` value exactness, timing).

Completes phase 6. Remaining ClickHouse work: phase 7 docs; small follow-ons (`delta_switched` parity); phase 5 (Rust ClickFlow consumer, separate repo).

🤖 Generated with [Claude Code](https://claude.com/claude-code)