### PR TITLE
docs(flows): document ClickHouse flow persistence (phase 7)

### DIFF
--- a/docs/modules/operation/pages/deep-dive/flows/aggregation.adoc
+++ b/docs/modules/operation/pages/deep-dive/flows/aggregation.adoc
@@ -2,6 +2,13 @@
 = Aggregate Flows with REST API
 :description: Learn how to use the REST API to aggregate flows in {page-component-title}, and alleviate computation load on the Elasticsearch cluster.
 
+[IMPORTANT]
+====
+This page describes the legacy Elasticsearch/Nephron aggregation path, which has been removed.
+{page-component-title} now persists flows in ClickHouse and maintains per-minute aggregates in-database using rollup materialized views created automatically with the flow schema — no external streaming aggregator or separate aggregate store is required.
+The REST API and query engine transparently use these rollups; the Elasticsearch-specific configuration below no longer applies.
+====
+
 The flow query engine supports rendering the top _N_ metrics from pre-aggregated documents stored in Elasticsearch.
 You can use these statistics to help alleviate computation load on the Elasticsearch cluster, particularly in environments with large volumes of flows (more than 10,000 per second).
 To use this functionality, you must <<deep-dive/flows/basic.adoc#kafka-forwarder-config, enable the Kafka forwarder>> and set up the streaming analytics tool to process flows and persist aggregates in Elasticsearch.

--- a/docs/modules/operation/pages/deep-dive/flows/basic.adoc
+++ b/docs/modules/operation/pages/deep-dive/flows/basic.adoc
@@ -1,7 +1,7 @@
 
 [[flows-basic]]
 = Basic Flows Setup
-:description: Get started with flows data collection in {page-component-title} including configuring Elasticsearch, Kafka, and protocol listeners.
+:description: Get started with flows data collection in {page-component-title} including configuring ClickHouse, Kafka, and protocol listeners.
 
 This section describes how to get started with flows to collect, enrich (classify), persist, and visualize flows.
 
@@ -11,26 +11,22 @@ Make sure that you have the following before you set up flows:
 
 * A configured {page-component-title} instance.
 * One or more devices that send flows visible to {page-component-title}, and that are monitored with SNMP.
-* Elasticsearch cluster set up with the https://github.com/OpenNMS/elasticsearch-drift-plugin[Elasticsearch Drift plugin] installed on every Elasticsearch node.
-** The Drift plugin persists and queries flows that {page-component-title} collects.
-The Drift version must match the targeted Elasticsearch version.
-** (Optional) Configure Elasticsearch variables like `search.max_buckets` or maximum heap size `ES-JAVA_OPTS` if the default values are not sufficient for your volume of flows or number of nodes.
-** A retention process to remove old flow indices so the disk does not fill up (for example, "keep _X_ days of flows").
-See <<deep-dive/elasticsearch/introduction.adoc#ga-elasticsearch-index-retention, Index retention>>.
-** {page-component-title} set up to monitor the Elasticsearch stack and generate an alarm if it goes down.
+* A https://clickhouse.com/[ClickHouse] server reachable from {page-component-title}.
+** {page-component-title} persists and queries flows directly in ClickHouse; the flow schema (tables and per-minute rollup materialized views) is created automatically on startup.
+** Retention is enforced by a table `TTL` (see `ttlDays` below), so no external index-retention process is required.
 * The OpenNMS plugin for Grafana configured to visualize flows.
 ** Configure the flow and performance data sources.
 
 [WARNING]
 ====
-Flows are high volume, and {page-component-title} does not expire them.
-Configure an index retention process before you collect flows in production, or the Elasticsearch disk can fill up.
-See <<deep-dive/elasticsearch/introduction.adoc#ga-elasticsearch-index-retention, Index retention>>.
+Flows are high volume.
+Set a `ttlDays` retention window appropriate for your disk capacity before you collect flows in production; without a TTL, ClickHouse retains every flow indefinitely.
 ====
 
-== Configure {page-component-title} to communicate with Elasticsearch
+== Configure {page-component-title} to persist flows to ClickHouse
 
-{page-component-title} must be set up to communicate with Elasticsearch and persist the collected flows data in a defined directory:
+{page-component-title} persists flows in-process to ClickHouse (the default, Kafka-free write path).
+Point it at your ClickHouse server:
 
 . Connect to your {page-component-title} xref:reference:karaf-shell/karaf-shell.adoc[Karaf shell]:
 +
@@ -39,59 +35,36 @@ See <<deep-dive/elasticsearch/introduction.adoc#ga-elasticsearch-index-retention
 ssh -p 8101 admin@localhost
 ----
 
-. Edit `$\{OPENNMS_HOME}/etc/org.opennms.features.flows.persistence.elastic.cfg` to configure flow persistence to use your Elasticsearch cluster:
+. Configure the ClickHouse connection:
 +
 [source, karaf]
 ----
-config:edit org.opennms.features.flows.persistence.elastic
-config:property-set elasticUrl http://elastic:9200
+config:edit org.opennms.features.flows.persistence.clickhouse
+config:property-set endpoint http://clickhouse:8123
 config:update
 ----
 
-. (Optional) Edit or create `$\{OPENNMS_HOME}/etc/org.opennms.features.flows.persistence.elastic.cfg` and configure persistence settings:
+. (Optional) Set any of the remaining persistence properties in `$\{OPENNMS_HOME}/etc/org.opennms.features.flows.persistence.clickhouse.cfg`:
 +
-[source, xml]
+[source, properties]
 ----
-elasticUrl = http://10.10.3.218:9200 <1>
-connTimeout = 30000
-readTimeout = 300000
-settings.index.number_of_replicas = 0
-settings.index.number_of_shards=1
-settings.index.refresh_interval=10s
-elasticIndexStrategy=daily
+endpoint = http://clickhouse:8123 <1>
+database = default
+username = default
+password =
+table = flows
+ttlDays = 30 <2>
+enablePersistence = true <3>
+bulkSize = 1000 <4>
+bulkFlushMs = 500
+maxBufferedFlows = 100000
 ----
-<1> Replace with comma-separated list of Elasticsearch nodes.
+<1> ClickHouse HTTP endpoint.
+<2> Retention window in days; the flow table's `TTL` drops rows older than this. Set to `0` to disable the TTL and retain flows indefinitely.
+<3> Set to `false` to disable the in-process write path (for example, when flows are written by the external Kafka consumer instead).
+<4> Batch-insert tuning: flush after `bulkSize` flows or `bulkFlushMs` milliseconds, buffering at most `maxBufferedFlows` (oldest dropped when full).
 
-** See <<deep-dive/elasticsearch/introduction.adoc#ga-elasticsearch-integration-configuration, General Elasticsearch configuration>> for a complete set of configuration options.
-
-== Configuring NetFlow Composable Templates
-
-OpenNMS supports (https://www.elastic.co/docs/manage-data/data-store/templates)[composable templates] for more flexible and modular management of Elasticsearch index settings.
-To enable composable templates for NetFlow data, update below configuration in Karaf:
-
-[source, karaf]
-----
-config:edit org.opennms.features.flows.persistence.elastic
-config:property-set useComposableTemplates true
-config:update
-----
-
-=== Managing NetFlow Templates and Policies
-
-NetFlow component and index templates can be managed from the following directory:
-
-`$\{OPENNMS_HOME}/etc/netflow-templates`
-
-You can customize existing templates, add new ones, or define Index Lifecycle Management (ILM) policies within this folder. Any valid Elasticsearch template or ILM JSON placed here will be picked up and applied by the system.
-
-When placing files in the netflow-templates directory:
-
-* Files intended as ILM policies should have names that include keywords such as ilm, lifecycle, or policy.
-* Files with names containing setting(s), mapping(s), alias(es), or component will be treated as component templates.
-* Files with names containing index or composable will be recognized as index templates.
-
-
-
+NOTE: For very high flow volumes you can offload persistence to an external Kafka-to-ClickHouse consumer: set `enablePersistence` to `false`, forward flows to Kafka (see <<kafka-forwarder-config, Configure Kafka forwarder>>), and run the consumer against the same ClickHouse server.
 
 == Multi-protocol listener
 
@@ -167,34 +140,19 @@ If you have trouble during or after configuration, refer to xref:deep-dive/flows
 [[kafka-forwarder-config]]
 == Configure Kafka forwarder
 
-Flows enriched with {page-component-title} node data can be forwarded to Kafka and persisted.
-By default, enriched flows are stored in the `flowsDocument` topic and the payloads are encoded using https://developers.google.com/protocol-buffers/[Google Protocol Buffers].
-See `flowdocument.proto` in the corresponding source definition for the model definitions.
+Enriched flows can also be forwarded to Kafka. This is the at-scale write path: an external Kafka-to-ClickHouse consumer reads the topic and persists the flows, so you can disable the in-process write path (`enablePersistence = false` on the `org.opennms.features.flows.persistence.clickhouse` PID).
+By default, enriched flows are published to the `flowDocuments` topic and the payloads are encoded using https://developers.google.com/protocol-buffers/[Google Protocol Buffers] (see `flowdocument.proto` for the model definitions); set `useJson` to `true` to publish JSON instead.
 
-To enable JSON support, set `useJson` to `true`.
+Forwarding is configured entirely on the `org.opennms.features.flows.persistence.kafka` PID:
 
-Follow these steps to configure forwarding flows to Kafka:
-
-. Enable Kafka forwarding:
-+
-[source, console]
-----
-$ ssh -p 8101 admin@localhost
-...
-admin@opennms()> config:edit org.opennms.features.flows.persistence.elastic
-admin@opennms()> config:property-set enableForwarding true
-admin@opennms()> config:update
-----
-
-. Configure the Kafka server for flows:
-+
 [source, console]
 ----
 $ ssh -p 8101 admin@localhost
 ...
 admin@opennms()> config:edit org.opennms.features.flows.persistence.kafka
+admin@opennms()> config:property-set enableForwarding true
 admin@opennms()> config:property-set bootstrap.servers 127.0.0.1:9092
-admin@opennms()> config:property-set topic opennms-flows
+admin@opennms()> config:property-set topic flowDocuments
 admin@opennms()> config:update
 ----
 
@@ -208,4 +166,5 @@ You can create rules to override the default classifications (see xref:deep-dive
 
 * xref:deep-dive/flows/distributed.adoc[Enable remote flows data collection] with Minions.
 * xref:deep-dive/flows/sentinel/sentinel.adoc[Scale to manage large volumes of flows data] with Sentinels.
-* Add https://github.com/OpenNMS/nephron[OpenNMS Nephron] for aggregation and streaming analytics.
+
+NOTE: Flow aggregation is performed in-database by ClickHouse per-minute rollup materialized views, created automatically with the schema. A separate streaming aggregator (previously OpenNMS Nephron) is no longer required.

--- a/docs/modules/operation/pages/deep-dive/flows/introduction.adoc
+++ b/docs/modules/operation/pages/deep-dive/flows/introduction.adoc
@@ -24,7 +24,6 @@ This section presents a set of procedures to set up flows that progress from a b
 * xref:deep-dive/flows/basic.adoc[Basic setup].
 * Collect flows data in a xref:deep-dive/flows/distributed.adoc[distributed or remote network].
 * Process a xref:deep-dive/flows/sentinel/sentinel.adoc[large volume of flows data].
-* Use https://github.com/OpenNMS/nephron[OpenNMS Nephron] to diagnose issues with flows at scale and queries taking too long.
 
 == How it works
 
@@ -35,14 +34,13 @@ At a high level, with a xref:deep-dive/flows/basic.adoc[basic setup], {page-comp
 . Flows are enriched:
 ** The xref:deep-dive/flows/classification-engine.adoc[flow support classification engine] tags flows and groups them under a name based on a set of rules.
 ** Metadata related to associated nodes (such as IDs and categories) are added to the flows.
-. Enriched flows are persisted in Elasticsearch and/or forwarded to Kafka.
-. (Optional) The OpenNMS streaming analytics tool aggregates flows and outputs them to Elasticsearch, Cortex, or Kafka.
+. Enriched flows are persisted in ClickHouse, either in-process (default) or by an external Kafka-to-ClickHouse consumer when flows are forwarded to Kafka.
+. Per-minute aggregates are maintained in-database by ClickHouse rollup materialized views, created automatically with the flow schema.
 
 You can access collected flows data in the following locations:
 
 * OpenNMS plugin for Grafana dashboards:
-** The "Flow Deep Dive" dashboard visualizes flows and aggregates that are stored in Elasticsearch using a flows datasource.
-** The "Cortex Flow Deep Dive" dashboard visualizes aggregates that are stored in Cortex using a Prometheus datasource.
+** The "Flow Deep Dive" dashboard visualizes flows and aggregates that are stored in ClickHouse using a flows datasource.
 * The REST API can generate summaries and time series data from the stored flows or aggregates.
 
 .Overview of flows integration


### PR DESCRIPTION
## What

**Phase 7** — update the flows operator docs now that flows persist to ClickHouse (the ES flow module is gone).

- **`basic.adoc`**: replace the Elasticsearch + Drift-plugin requirements and the "communicate with Elasticsearch" configuration with the **ClickHouse setup** — the `org.opennms.features.flows.persistence.clickhouse` PID (`endpoint`/`database`/`username`/`password`/`table`/`ttlDays`/`enablePersistence`/`bulk*`, matching the blueprint defaults), plus a note on the external Kafka-to-ClickHouse consumer for scale. Retention is now a table `TTL` (`ttlDays`), not an ES index-retention process. Removed the Elasticsearch-only "composable templates" / ILM sections. **Also fixed the Kafka forwarder section** — `enableForwarding`/`topic`/`bootstrap.servers` all live on the `...persistence.kafka` PID (the doc used the removed elastic PID and the wrong topic name; default topic is `flowDocuments`).
- **`introduction.adoc`**: persistence is ClickHouse; per-minute aggregates are in-database rollup materialized views (no external streaming aggregator/Nephron).
- **`aggregation.adoc`**: banner noting the ES/Nephron aggregation path is removed and superseded by the in-database ClickHouse rollups.

## Notes
- The Antora build was **not** run locally (heavy); changes are content-only within existing pages — no file renames, no new xrefs (a couple of ES-page xrefs were removed).
- Deeper ES-specific pages (the `elasticsearch/features/flows` field reference, flow `troubleshooting`) are left for a follow-up.

🤖 Generated with [Claude Code](https://claude.com/claude-code)