### PR TITLE
test(flows): tidy unused imports in flow e2e ITs [full-ci]

### DIFF
--- a/e2e-tests/src/test/java/org/opennms/smoketest/flow/SinglePortFlowsIT.java
+++ b/e2e-tests/src/test/java/org/opennms/smoketest/flow/SinglePortFlowsIT.java
@@ -26,15 +26,12 @@ import org.junit.Test;
 import org.opennms.smoketest.stacks.OpenNMSStack;
 import org.opennms.smoketest.stacks.NetworkProtocol;
 import org.opennms.smoketest.stacks.StackModel;
-import org.opennms.smoketest.telemetry.FlowPacket;
 import org.opennms.smoketest.telemetry.FlowTestBuilder;
 import org.opennms.smoketest.telemetry.FlowTester;
 import org.opennms.smoketest.telemetry.Packets;
 import org.opennms.smoketest.telemetry.Sender;
 
 import java.net.InetSocketAddress;
-import java.util.List;
-import java.util.stream.Collectors;
 
 /**
  * Verifies that sending flow packets to a single port is dispatching the flows in the according queues.

--- a/e2e-tests/src/test/java/org/opennms/smoketest/flow/TCPFlowsIT.java
+++ b/e2e-tests/src/test/java/org/opennms/smoketest/flow/TCPFlowsIT.java
@@ -25,8 +25,6 @@ import java.io.BufferedOutputStream;
 import java.io.OutputStream;
 import java.net.InetSocketAddress;
 import java.net.Socket;
-import java.util.List;
-import java.util.stream.Collectors;
 
 import org.junit.ClassRule;
 import org.junit.Test;


### PR DESCRIPTION
## What

Small cleanup — remove pre-existing unused imports (`List`, `Collectors`, and an unused `FlowPacket` in `SinglePortFlowsIT`) in the flow smoke ITs left over from the ClickHouse e2e rewrite.

## Why now
Primarily to carry **`[full-ci]`** and run the **full e2e suite against `main`**. The ClickHouse flow e2e harness landed on `main` via #182 (bundled into that PR by a branching mistake) **without** a full-CI run, so the re-enabled flow ITs are currently unvalidated. This PR triggers `e2e-tests-*` to exercise:
- `flow/{ClockSkewIT, SinglePortFlowsIT, TCPFlowsIT}`
- `sentinel/{FlowStackJmsIT, FlowStackKafkaIT, SinglePortFlowsIT, KafkaCompressionZSTDFlowIT}`

against a real ClickHouse-backed stack. Expect any failures to be in the classification `application`-value exactness or container boot timing — to be fixed forward.

`e2e-tests` reactor compiles.

🤖 Generated with [Claude Code](https://claude.com/claude-code)