### PR TITLE
ci: cancel superseded in-progress runs per branch/PR

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -13,6 +13,14 @@ on:
 
 permissions: write-all
 
+# Cancel an in-progress run when a newer run for the same branch or PR is triggered, so superseded
+# builds free their runners instead of sitting in the queue. github.ref is unique per branch
+# (refs/heads/<branch>) and per PR (refs/pull/<n>/merge), so pushing again to the same branch/PR
+# supersedes the older run. Release tag builds (refs/tags/v*) are exempt so they always complete.
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: ${{ !startsWith(github.ref, 'refs/tags/') }}
+
 jobs:
   decide-scope:
     runs-on: ubuntu-latest


### PR DESCRIPTION
## What

Add a workflow-level `concurrency` group to `.github/workflows/main.yml` so that pushing again to the same branch or PR **cancels the older in-progress run** instead of leaving it queued behind the newer one. Under runner contention this frees runners and shortens feedback time (superseded builds stop instead of running to completion).

```yaml
concurrency:
  group: ${{ github.workflow }}-${{ github.ref }}
  cancel-in-progress: ${{ !startsWith(github.ref, 'refs/tags/') }}
```

- `github.ref` is unique per branch (`refs/heads/<branch>`) and per PR (`refs/pull/<n>/merge`), so a new push to the same branch/PR supersedes the older run; distinct branches/PRs never cancel each other.
- **Release tag builds (`refs/tags/v*`) are exempt** (`cancel-in-progress` evaluates to `false` for tags) so release pipelines always run to completion.

YAML validated locally. `.github/workflows/**` is a trip-wire path, so this PR itself runs a full build; the behavior takes effect for runs on branches/PRs once merged.

🤖 Generated with [Claude Code](https://claude.com/claude-code)