### PR TITLE
chore(merge): re-sync with upstream PR #8642 (NMS-20044) before cutting v38.1.0 [full-ci]

### DIFF
--- a/container/bridge/proxy/pom.xml
+++ b/container/bridge/proxy/pom.xml
@@ -34,6 +34,11 @@
             <scope>provided</scope>
         </dependency>
         <dependency>
+            <groupId>org.slf4j</groupId>
+            <artifactId>slf4j-api</artifactId>
+            <scope>provided</scope>
+        </dependency>
+        <dependency>
             <groupId>junit</groupId>
             <artifactId>junit</artifactId>
             <scope>test</scope>

--- a/container/bridge/proxy/src/main/java/org/opennms/container/web/bridge/proxy/ProxyFilter.java
+++ b/container/bridge/proxy/src/main/java/org/opennms/container/web/bridge/proxy/ProxyFilter.java
@@ -47,6 +47,8 @@ import org.opennms.container.web.bridge.proxy.trackers.ServletTracker;
 import org.osgi.framework.BundleContext;
 import org.osgi.framework.InvalidSyntaxException;
 import org.osgi.util.tracker.ServiceTracker;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 
 /**
  * The Apache Felix Http Bridge requires a Http Proxy on the SErvlet Container (Jetty) Side in order to work properly.
@@ -59,6 +61,8 @@ import org.osgi.util.tracker.ServiceTracker;
  * @author mvrueden
  */
 public class ProxyFilter implements Filter, RequestHandlerRegistry {
+    private static final Logger LOG = LoggerFactory.getLogger(ProxyFilter.class);
+
     private BundleContext bundleContext;
     private DispatcherTracker dispatcherTracker;
     /**
@@ -75,8 +79,11 @@ public class ProxyFilter implements Filter, RequestHandlerRegistry {
     public void init(FilterConfig filterConfig) throws ServletException {
         bundleContext = getBundleContext(filterConfig.getServletContext());
         if (bundleContext == null) {
-            filterConfig.getServletContext().log(
-                    "No Karaf BundleContext is available; the OSGi HTTP proxy filter is disabled.");
+            // This filter is attached once, when the web application starts. If Karaf
+            // comes up later, or is restarted on its own, the proxy stays disabled
+            // until the web application is restarted as well.
+            LOG.warn("No Karaf BundleContext is available; the OSGi HTTP proxy filter is disabled. "
+                    + "Requests served by OSGi-registered servlets and resources will not be reachable.");
             return;
         }
         try {

--- a/container/bridge/proxy/src/test/java/org/opennms/container/web/bridge/proxy/ProxyFilterTest.java
+++ b/container/bridge/proxy/src/test/java/org/opennms/container/web/bridge/proxy/ProxyFilterTest.java
@@ -48,8 +48,8 @@ public class ProxyFilterTest {
         filter.doFilter(request, response, chain);
         filter.destroy();
 
+        // Without a BundleContext the filter must stay out of the way rather than
+        // failing the request or the web application startup.
         verify(chain).doFilter(request, response);
-        verify(servletContext).log(
-                "No Karaf BundleContext is available; the OSGi HTTP proxy filter is disabled.");
     }
 }

--- a/container/daemon/pom.xml
+++ b/container/daemon/pom.xml
@@ -12,28 +12,16 @@
 
   <groupId>org.opennms.container</groupId>
   <artifactId>org.opennms.container.daemon</artifactId>
-  <packaging>bundle</packaging>
+  <!--
+    Deliberately a plain jar rather than an OSGi bundle. This artifact owns the
+    embedded Karaf lifecycle and publishes its BundleContext through the static
+    KarafContext holder, so it has to be loaded exactly once, from the system
+    class path in $OPENNMS_HOME/lib. Packaging it as a bundle would invite it to
+    be installed inside the very framework it starts, which would produce a
+    second holder and silently disable the OSGi HTTP proxy.
+  -->
+  <packaging>jar</packaging>
   <name>OpenNMS :: OSGi Container :: Daemon</name>
-
-  <build>
-    <plugins>
-      <plugin>
-        <groupId>org.apache.felix</groupId>
-        <artifactId>maven-bundle-plugin</artifactId>
-        <extensions>true</extensions>
-        <configuration>
-          <instructions>
-            <Bundle-SymbolicName>${project.groupId}.${project.artifactId}</Bundle-SymbolicName>
-            <Bundle-Version>${project.version}</Bundle-Version>
-            <Export-Package>
-              org.opennms.container.daemon;version="${project.version}",
-              org.opennms.container.daemon.jmx;version="${project.version}"
-            </Export-Package>
-          </instructions>
-        </configuration>
-      </plugin>
-    </plugins>
-  </build>
 
   <dependencies>
     <dependency>

--- a/container/jaas-login-module/pom.xml
+++ b/container/jaas-login-module/pom.xml
@@ -53,6 +53,12 @@
             <artifactId>opennms-config-api</artifactId>
             <scope>provided</scope>
         </dependency>
+        <!-- For the catalog of valid OpenNMS security roles. -->
+        <dependency>
+            <groupId>org.opennms</groupId>
+            <artifactId>opennms-web-api</artifactId>
+            <scope>provided</scope>
+        </dependency>
         <dependency>
             <groupId>org.osgi</groupId>
             <artifactId>osgi.core</artifactId>

--- a/container/jaas-login-module/src/main/java/org/opennms/container/jaas/OpenNMSLoginModule.java
+++ b/container/jaas-login-module/src/main/java/org/opennms/container/jaas/OpenNMSLoginModule.java
@@ -41,6 +41,7 @@ import org.apache.karaf.jaas.boot.principal.RolePrincipal;
 import org.apache.karaf.jaas.modules.AbstractKarafLoginModule;
 import org.opennms.netmgt.config.api.UserConfig;
 import org.opennms.netmgt.config.users.User;
+import org.opennms.web.api.Authentication;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -102,11 +103,14 @@ public class OpenNMSLoginModule extends AbstractKarafLoginModule {
             throw loginException;
         }
 
-        principals = createPrincipals(configUser);
-        if (!hasAdminRole(configUser)) {
+        final Set<Principal> rolePrincipals = createPrincipals(configUser);
+
+        // This login module guards the OSGi console, so only administrators may log in.
+        if (!rolePrincipals.contains(new RolePrincipal(Authentication.ROLE_ADMIN))) {
             throw new LoginException("User " + user + " is not an administrator! OSGi console access is forbidden.");
         }
 
+        principals = rolePrincipals;
         succeeded = true;
         LOG.debug("Successfully logged in {}.", user);
         return true;
@@ -118,23 +122,26 @@ public class OpenNMSLoginModule extends AbstractKarafLoginModule {
 
     private Set<Principal> createPrincipals(final User configUser) {
         final Set<Principal> principals = new HashSet<>();
-        for (String configuredRole : configUser.getRoles()) {
-            final String role = normalizeRole(configuredRole);
-            principals.add(new RolePrincipal(role));
-            principals.add(new RolePrincipal(role.toLowerCase(Locale.ROOT)));
-            principals.add(new RolePrincipal(configuredRole));
+        for (final String configuredRole : configUser.getRoles()) {
+            // Only roles known to OpenNMS grant privileges; anything else in users.xml is ignored.
+            if (!Authentication.isValidRole(configuredRole)) {
+                LOG.debug("Ignoring role {} of user {}: it is not a known OpenNMS role.", configuredRole, user);
+                continue;
+            }
+            addRolePrincipals(principals, configuredRole);
+            if (Authentication.ROLE_ADMIN.equals(configuredRole)) {
+                // ROLE_ADMIN implies ROLE_USER, as it does for the web user interface.
+                addRolePrincipals(principals, Authentication.ROLE_USER);
+            }
         }
         LOG.debug("Created principals from user roles {}: {}", configUser.getRoles(), principals);
         return principals;
     }
 
-    private boolean hasAdminRole(final User configUser) {
-        return configUser.getRoles().stream()
-                .map(OpenNMSLoginModule::normalizeRole)
-                .anyMatch("admin"::equalsIgnoreCase);
-    }
-
-    private static String normalizeRole(final String role) {
-        return role.replaceFirst("^[Rr][Oo][Ll][Ee]_", "");
+    private static void addRolePrincipals(final Set<Principal> principals, final String role) {
+        final String name = role.replaceFirst("^[Rr][Oo][Ll][Ee]_", "");
+        principals.add(new RolePrincipal(name));
+        principals.add(new RolePrincipal(name.toLowerCase(Locale.ROOT)));
+        principals.add(new RolePrincipal(role));
     }
 }

--- a/container/jaas-login-module/src/test/java/org/opennms/container/jaas/OpenNMSLoginModuleTest.java
+++ b/container/jaas-login-module/src/test/java/org/opennms/container/jaas/OpenNMSLoginModuleTest.java
@@ -21,6 +21,7 @@
  */
 package org.opennms.container.jaas;
 
+import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertThrows;
 import static org.junit.Assert.assertTrue;
 import static org.mockito.Mockito.mock;
@@ -28,6 +29,8 @@ import static org.mockito.Mockito.when;
 
 import java.util.List;
 import java.util.Map;
+import java.util.Set;
+import java.util.stream.Collectors;
 
 import javax.security.auth.Subject;
 import javax.security.auth.callback.Callback;
@@ -39,11 +42,29 @@ import javax.security.auth.login.FailedLoginException;
 import javax.security.auth.login.LoginException;
 
 import org.apache.karaf.jaas.boot.principal.RolePrincipal;
+import org.junit.After;
+import org.junit.Before;
+import org.junit.Rule;
 import org.junit.Test;
+import org.junit.rules.TemporaryFolder;
 import org.opennms.netmgt.config.api.UserConfig;
 import org.opennms.netmgt.config.users.User;
 
 public class OpenNMSLoginModuleTest {
+    @Rule
+    public TemporaryFolder m_opennmsHome = new TemporaryFolder();
+
+    @Before
+    public void setUp() {
+        // Keep Authentication from picking up a security-roles.properties outside of this test.
+        System.setProperty("opennms.home", m_opennmsHome.getRoot().getAbsolutePath());
+    }
+
+    @After
+    public void tearDown() {
+        System.clearProperty("opennms.home");
+    }
+
     @Test
     public void authenticatesAdminUsingOnlyUserConfig() throws Exception {
         final UserConfig userConfig = userConfig("admin", "secret", "ROLE_ADMIN", "ROLE_USER");
@@ -52,10 +73,19 @@ public class OpenNMSLoginModuleTest {
 
         assertTrue(module.login());
         assertTrue(module.commit());
-        assertTrue(subject.getPrincipals(RolePrincipal.class).stream()
-                .anyMatch(principal -> "admin".equals(principal.getName())));
-        assertTrue(subject.getPrincipals(RolePrincipal.class).stream()
-                .anyMatch(principal -> "ROLE_ADMIN".equals(principal.getName())));
+        assertEquals(Set.of("ADMIN", "admin", "ROLE_ADMIN", "USER", "user", "ROLE_USER"), roleNames(subject));
+    }
+
+    @Test
+    public void grantsRoleUserToAdministrators() throws Exception {
+        // ROLE_ADMIN implies ROLE_USER, as it does for the web user interface.
+        final UserConfig userConfig = userConfig("admin", "secret", "ROLE_ADMIN");
+        final Subject subject = new Subject();
+        final OpenNMSLoginModule module = loginModule(userConfig, subject, "admin", "secret");
+
+        assertTrue(module.login());
+        assertTrue(module.commit());
+        assertEquals(Set.of("ADMIN", "admin", "ROLE_ADMIN", "USER", "user", "ROLE_USER"), roleNames(subject));
     }
 
     @Test
@@ -68,11 +98,49 @@ public class OpenNMSLoginModuleTest {
     }
 
     @Test
+    public void rejectsRolesThatOnlyResembleTheAdminRole() throws Exception {
+        // None of these are valid OpenNMS roles, so none of them may unlock the OSGi console.
+        for (final String role : List.of("admin", "Admin", "role_admin", "ROLE_ADMINISTRATOR")) {
+            final UserConfig userConfig = userConfig("someone", "secret", role);
+            final OpenNMSLoginModule module = loginModule(userConfig, new Subject(), "someone", "secret");
+
+            final LoginException exception = assertThrows("role " + role + " must not grant console access",
+                    LoginException.class, module::login);
+            assertTrue(exception.getMessage().contains("is not an administrator"));
+        }
+    }
+
+    @Test
+    public void ignoresRolesThatOpenNmsDoesNotKnow() throws Exception {
+        final UserConfig userConfig = userConfig("admin", "secret", "ROLE_ADMIN", "ROLE_MADE_UP");
+        final Subject subject = new Subject();
+        final OpenNMSLoginModule module = loginModule(userConfig, subject, "admin", "secret");
+
+        assertTrue(module.login());
+        assertTrue(module.commit());
+        assertEquals(Set.of("ADMIN", "admin", "ROLE_ADMIN", "USER", "user", "ROLE_USER"), roleNames(subject));
+    }
+
+    @Test
     public void rejectsInvalidPasswords() throws Exception {
         final UserConfig userConfig = userConfig("admin", "secret", "ROLE_ADMIN");
         final OpenNMSLoginModule module = loginModule(userConfig, new Subject(), "admin", "wrong");
 
         assertThrows(FailedLoginException.class, module::login);
+    }
+
+    @Test
+    public void failsWhenUserConfigIsUnavailable() {
+        final OpenNMSLoginModule module = loginModule(null, new Subject(), "admin", "secret");
+
+        final LoginException exception = assertThrows(LoginException.class, module::login);
+        assertTrue(exception.getMessage().contains("UserConfig service is unavailable"));
+    }
+
+    private static Set<String> roleNames(final Subject subject) {
+        return subject.getPrincipals(RolePrincipal.class).stream()
+                .map(RolePrincipal::getName)
+                .collect(Collectors.toSet());
     }
 
     private static UserConfig userConfig(final String username, final String password, final String... roles)

--- a/container/servlet/src/main/java/org/opennms/container/web/WebAppListener.java
+++ b/container/servlet/src/main/java/org/opennms/container/web/WebAppListener.java
@@ -21,20 +21,26 @@ import javax.servlet.ServletContextListener;
 
 import org.opennms.container.daemon.KarafContext;
 import org.osgi.framework.BundleContext;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 
 /**
  * Publishes the context of the OpenNMS-managed Karaf service to the servlet
  * bridge. Karaf lifecycle ownership remains outside the web application.
  */
 public class WebAppListener implements ServletContextListener {
+    private static final Logger LOG = LoggerFactory.getLogger(WebAppListener.class);
+
     @Override
     public void contextInitialized(final ServletContextEvent event) {
         final BundleContext bundleContext = getBundleContext();
         if (bundleContext != null) {
             event.getServletContext().setAttribute(BundleContext.class.getName(), bundleContext);
         } else {
-            event.getServletContext().log(
-                    "Karaf is not running; OSGi servlet and resource proxying is disabled.");
+            // The context is read once, at web application startup: starting Karaf
+            // afterwards does not enable proxying until the web application restarts.
+            LOG.warn("Karaf is not running; OSGi servlet and resource proxying is disabled. "
+                    + "Check that the Karaf service is enabled in service-configuration.xml.");
         }
     }
 

--- a/container/servlet/src/test/java/org/opennms/container/web/WebAppListenerTest.java
+++ b/container/servlet/src/test/java/org/opennms/container/web/WebAppListenerTest.java
@@ -64,9 +64,9 @@ public class WebAppListenerTest {
 
         listener.contextInitialized(event);
 
+        // Startup must succeed; the bridge simply has no context to publish.
         verify(servletContext, never()).setAttribute(
                 org.mockito.ArgumentMatchers.eq(BundleContext.class.getName()),
                 org.mockito.ArgumentMatchers.any());
-        verify(servletContext).log("Karaf is not running; OSGi servlet and resource proxying is disabled.");
     }
 }

--- a/docs/modules/reference/pages/daemons/introduction.adoc
+++ b/docs/modules/reference/pages/daemons/introduction.adoc
@@ -3,7 +3,19 @@
 :description: Learn about the daemon sub-services available in OpenNMS {page-component-title} and how to enable or disable them.
 
 The {page-component-title} service is composed of several daemon "sub-services" that each perform a specific set of tasks.
-You can enable and disable them via `$\{OPENNMS_HOME}/etc/service-configuration.xml`.
+You can enable and disable them via `$\{OPENNMS_HOME}/etc/service-configuration.xml`, or with the container environment variables listed below.
+
+To turn a daemon off, set `enabled="false"` on its `<service>` entry:
+
+[source, xml]
+----
+<service enabled="false"><name>OpenNMS:Name=Syslogd</name></service>
+----
+
+IMPORTANT: Do not delete `<service>` entries and do not change their order.
+{page-component-title} ships a default catalog that defines the complete set of daemons and the order in which they start, and your file is applied on top of it as a set of enable/disable overrides.
+A deleted entry is therefore restored at its default state on the next start, and reordering entries has no effect because the startup order always comes from the default catalog.
+An entry naming a daemon that is not in the catalog is ignored, and a warning is logged.
 
 See xref:operation:deep-dive/admin/configuration/daemon-config-files.adoc[] section for details on sending daemon reload commands.
 
@@ -63,10 +75,12 @@ See xref:operation:deep-dive/admin/configuration/daemon-config-files.adoc[] sect
 
 | Karaf
 | The Karaf runtime hosts the OSGi services and features used by the {page-component-title} system.
+If you disable it, you must also disable KarafStartupMonitor.
 | `CORE_SERVICE_KARAF_ENABLED=true`
 
 | KarafStartupMonitor
 | Used in startup script to detect if Karaf started properly.
+It waits for the Karaf runtime to come up and fails startup if it does not, so leaving it enabled while Karaf is disabled delays and then fails startup.
 | `CORE_SERVICE_KARAFSTARTUPMONITOR_ENABLED=true`
 
 | Notifd

--- a/features/measurements/api/src/main/resources/META-INF/opennms/component-service.xml
+++ b/features/measurements/api/src/main/resources/META-INF/opennms/component-service.xml
@@ -14,8 +14,8 @@
   <context:annotation-config />
 
   <!--
-    The bean is defined twice. Once here, and in component-measurement.xml.
-    The "component-measurement.xml" application context does not need to know about the "osgi:" definition, otherwise all
+    The bean is defined twice. Once here, and in component-dao.xml.
+    The "component-dao.xml" application context does not need to know about the "osgi:" definition, otherwise all
     modules need to depend on core-soa and include "component-soa.xml and component-soa-osgi.xml".
     To prevent this, only for the inclusion of the "onmsgi:service" the bean with id "measurementFetchStrategyFactory" is defined twice.
   -->

--- a/opennms-config-model/src/test/java/org/opennms/netmgt/config/service/KarafWebServiceWiringTest.java
+++ b/opennms-config-model/src/test/java/org/opennms/netmgt/config/service/KarafWebServiceWiringTest.java
@@ -1,21 +1,23 @@
 /*
  * Licensed to The OpenNMS Group, Inc (TOG) under one or more
  * contributor license agreements.  See the LICENSE.md file
- * distributed with this work for additional information regarding
- * copyright ownership.
+ * distributed with this work for additional information
+ * regarding copyright ownership.
  *
- * TOG licenses this file to You under the GNU Affero General Public License
- * Version 3 (the "License") or (at your option) any later version.  You may
- * not use this file except in compliance with the License.  You may obtain a
- * copy of the License at:
+ * TOG licenses this file to You under the GNU Affero General
+ * Public License Version 3 (the "License") or (at your option)
+ * any later version.  You may not use this file except in
+ * compliance with the License.  You may obtain a copy of the
+ * License at:
  *
  *      https://www.gnu.org/licenses/agpl-3.0.txt
  *
- * Unless required by applicable law or agreed to in writing, software
- * distributed under the License is distributed on an "AS IS" BASIS,
- * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
- * See the License for the specific language governing permissions and
- * limitations under the License.
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND,
+ * either express or implied.  See the License for the specific
+ * language governing permissions and limitations under the
+ * License.
  */
 package org.opennms.netmgt.config.service;
 

--- a/opennms-config-model/src/test/java/org/opennms/netmgt/config/service/ServiceCatalogParityTest.java
+++ b/opennms-config-model/src/test/java/org/opennms/netmgt/config/service/ServiceCatalogParityTest.java
@@ -5,17 +5,19 @@
  * regarding copyright ownership.
  *
  * TOG licenses this file to You under the GNU Affero General
- * Public License Version 3 (the "License"); you may not use this file
- * except in compliance with the License.  You may obtain a copy of the
+ * Public License Version 3 (the "License") or (at your option)
+ * any later version.  You may not use this file except in
+ * compliance with the License.  You may obtain a copy of the
  * License at:
  *
  *      https://www.gnu.org/licenses/agpl-3.0.txt
  *
- * Unless required by applicable law or agreed to in writing, software
- * distributed under the License is distributed on an "AS IS" BASIS,
- * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
- * See the License for the specific language governing permissions and
- * limitations under the License.
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND,
+ * either express or implied.  See the License for the specific
+ * language governing permissions and limitations under the
+ * License.
  */
 package org.opennms.netmgt.config.service;
 

--- a/opennms-dao/src/main/java/org/opennms/netmgt/dao/support/PropertiesGraphDao.java
+++ b/opennms-dao/src/main/java/org/opennms/netmgt/dao/support/PropertiesGraphDao.java
@@ -90,23 +90,37 @@ public class PropertiesGraphDao implements GraphDao, InitializingBean {
     public PropertiesGraphDao() {
     }
 
-    private void initPrefab() throws IOException {
+    private void initPrefab() {
         for (Map.Entry<String, Resource> configEntry : getPrefabConfigs().entrySet()) {
             if (!configEntry.getValue().exists()) {
                 LOG.warn("Skipping missing prefab graph configuration for type '{}': {}", configEntry.getKey(), configEntry.getValue());
                 continue;
             }
-            loadProperties(configEntry.getKey(), configEntry.getValue());
+            // Graphs are a presentation concern: a configuration that cannot be read or
+            // is missing required properties must degrade graphing of that type rather
+            // than prevent the Spring context holding this DAO from starting, which
+            // would stop OpenNMS from starting at all.
+            try {
+                loadProperties(configEntry.getKey(), configEntry.getValue());
+            } catch (final Exception e) {
+                LOG.error("Failed to load prefab graph configuration of type '{}' from {}. Graphs of this type will be unavailable.",
+                        configEntry.getKey(), configEntry.getValue(), e);
+            }
         }
     }
 
-    private void initAdhoc() throws IOException {
+    private void initAdhoc() {
         for (Map.Entry<String, Resource> configEntry : getAdhocConfigs().entrySet()) {
             if (!configEntry.getValue().exists()) {
                 LOG.warn("Skipping missing ad hoc graph configuration for type '{}': {}", configEntry.getKey(), configEntry.getValue());
                 continue;
             }
-            loadAdhocProperties(configEntry.getKey(), configEntry.getValue());
+            try {
+                loadAdhocProperties(configEntry.getKey(), configEntry.getValue());
+            } catch (final Exception e) {
+                LOG.error("Failed to load ad hoc graph configuration of type '{}' from {}. Ad hoc graphs of this type will be unavailable.",
+                        configEntry.getKey(), configEntry.getValue(), e);
+            }
         }
     }
 

--- a/opennms-dao/src/test/java/org/opennms/netmgt/dao/support/PropertiesGraphDaoIT.java
+++ b/opennms-dao/src/test/java/org/opennms/netmgt/dao/support/PropertiesGraphDaoIT.java
@@ -215,6 +215,33 @@ public class PropertiesGraphDaoIT extends PropertiesGraphDaoITCase {
         assertTrue(dao.getAllPrefabGraphs().isEmpty());
         MockLogAppender.assertLogAtLevel(Level.WARN);
     }
+
+    /**
+     * A graph configuration that exists but cannot be parsed must not prevent
+     * initialization either, otherwise the Spring context that holds this DAO
+     * fails to start and takes the rest of OpenNMS with it.
+     */
+    @Test
+    public void testUnparseableConfiguredGraphResourcesDoNotPreventInitialization() throws Exception {
+        m_testSpecificLoggingTest = true;
+        final File borkedFile = m_fileAnticipator.tempFile("snmp-graph.properties");
+
+        // 'command.prefix' and 'output.mime' are required, so this fails with a
+        // DataAccessResourceFailureException rather than an IOException.
+        m_outputStream = new FileOutputStream(borkedFile);
+        m_writer = new OutputStreamWriter(m_outputStream, StandardCharsets.UTF_8);
+        m_writer.write("reports=mib2.bits\n");
+        m_writer.close();
+        m_outputStream.close();
+
+        final Map<String, Resource> prefabConfigs = new HashMap<>();
+        prefabConfigs.put("performance", new FileSystemResource(borkedFile));
+
+        final PropertiesGraphDao dao = createPropertiesGraphDao(prefabConfigs, s_emptyMap);
+
+        assertTrue(dao.getAllPrefabGraphs().isEmpty());
+        MockLogAppender.assertLogAtLevel(Level.ERROR);
+    }
     
     @Test
     public void testNoType() throws Exception {

--- a/smoke-test/src/test/java/org/opennms/smoketest/KarafWithoutJettyIT.java
+++ b/smoke-test/src/test/java/org/opennms/smoketest/KarafWithoutJettyIT.java
@@ -5,17 +5,19 @@
  * regarding copyright ownership.
  *
  * TOG licenses this file to You under the GNU Affero General
- * Public License Version 3 (the "License"); you may not use this file
- * except in compliance with the License.  You may obtain a copy of the
+ * Public License Version 3 (the "License") or (at your option)
+ * any later version.  You may not use this file except in
+ * compliance with the License.  You may obtain a copy of the
  * License at:
  *
  *      https://www.gnu.org/licenses/agpl-3.0.txt
  *
- * Unless required by applicable law or agreed to in writing, software
- * distributed under the License is distributed on an "AS IS" BASIS,
- * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
- * See the License for the specific language governing permissions and
- * limitations under the License.
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND,
+ * either express or implied.  See the License for the specific
+ * language governing permissions and limitations under the
+ * License.
  */
 package org.opennms.smoketest;
 

--- a/smoke-test/src/test/java/org/opennms/smoketest/OpenNMSWithoutKarafIT.java
+++ b/smoke-test/src/test/java/org/opennms/smoketest/OpenNMSWithoutKarafIT.java
@@ -4,18 +4,20 @@
  * distributed with this work for additional information
  * regarding copyright ownership.
  *
- * This program is free software: you can redistribute it and/or modify
- * it under the terms of the GNU Affero General Public License as published
- * by the Free Software Foundation, either version 3 of the License, or
- * (at your option) any later version.
+ * TOG licenses this file to You under the GNU Affero General
+ * Public License Version 3 (the "License") or (at your option)
+ * any later version.  You may not use this file except in
+ * compliance with the License.  You may obtain a copy of the
+ * License at:
  *
- * This program is distributed in the hope that it will be useful,
- * but WITHOUT ANY WARRANTY; without even the implied warranty of
- * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
- * GNU Affero General Public License for more details.
+ *      https://www.gnu.org/licenses/agpl-3.0.txt
  *
- * You should have received a copy of the GNU Affero General Public License
- * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND,
+ * either express or implied.  See the License for the specific
+ * language governing permissions and limitations under the
+ * License.
  */
 package org.opennms.smoketest;
 


### PR DESCRIPTION
We took [OpenNMS/opennms#8642](https://github.com/OpenNMS/opennms/pull/8642) early and deliberately, at head `92b9739be62`. That PR is **still open**, still approved, and has since gained a fourth commit — so v38.1.0 was about to ship a knowingly stale variant of it. This snapshots forward to `7ccf4550ce1`.

## What the new commit brings

- **`container/daemon` is packaged as a plain jar, not an OSGi bundle.** It owns the embedded Karaf lifecycle and publishes its `BundleContext` via the static `KarafContext` holder, so it must load exactly once from the system class path. Packaging it as a bundle invites installation *inside the framework it starts*, producing a second holder and silently disabling the OSGi HTTP proxy.
- **`OpenNMSLoginModule`** grants privileges only for roles OpenNMS actually knows, and checks the `ROLE_ADMIN` principal explicitly rather than inferring it. This guards the OSGi console.
- **`PropertiesGraphDao`** no longer lets an unreadable prefab-graph configuration abort the Spring context — graphing of that type degrades instead of stopping OpenNMS from starting at all.
- **`ProxyFilter` / `WebAppListener`** log via SLF4J with actionable messages instead of `servletContext.log`.

## I verified the packaging bug was latent, not live

Before taking the fix I checked whether we actually hit it: the daemon jar is in `lib/`, **absent from `system/`**, and no Karaf feature references it — so nothing was installing it into the framework. Taking the fix anyway, because the trap is real for anyone who later adds it to a feature.

After the merge, confirmed in the built assembly: jar present in `lib/`, absent from `system/`, **0 OSGi headers** in its manifest, both `KarafDaemon` classes intact.

## What auto-merge got right — checked, not assumed

The merge was conflict-free, which is exactly when things go wrong quietly:

| file | outcome |
|---|---|
| `container/daemon/pom.xml` | keeps **our** parent `38.0.2-SNAPSHOT` **and** takes **their** `packaging=jar` |
| `ServiceCatalogParityTest` | keeps our `e2e-tests` path and the dropped confd entry |
| `OpenNMSWithoutKarafIT` | keeps `CORE_SERVICE_TRAPD_ENABLED=false`, our workaround for #193 |

Upstream still carries `37.0.0-SNAPSHOT` in that daemon pom. That stale-version trap has now appeared **twice** — after the path-outage provider — and will need watching on every future new-module merge.

New dependencies resolve here: `opennms-web-api` (role catalog) and `slf4j-api`.

## CI

This touches no trip-wire path, so it would otherwise get a scoped build that skips e2e. Given it changes daemon packaging and Karaf console auth — and that we're cutting a release from it — `[full-ci]` is set deliberately to force the whole suite.

Verified locally: `make quick-build` green.